### PR TITLE
Resolved lookdev validation

### DIFF
--- a/colorbleed/plugins/maya/publish/validate_look_sets.py
+++ b/colorbleed/plugins/maya/publish/validate_look_sets.py
@@ -45,7 +45,8 @@ class ValidateLookSets(pyblish.api.InstancePlugin):
         relationships = instance.data["lookData"]["relationships"]
         invalid = []
 
-        with context.renderlayer("defaultRenderLayer"):
+        renderlayer = instance.data.get("renderlayer", "defaultRenderLayer")
+        with context.renderlayer(renderlayer):
             for node in instance:
                 # get the connected objectSets of the node
                 sets = lib.get_related_sets(node)


### PR DESCRIPTION
Updated context renderlayer switching, Maya now correctly switches to the right renderlayer when validating collected lookdev content per layer.