### PR TITLE
Implement draft version for PLN-10: notify outdated containers w/ pop-up

### DIFF
--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -1,0 +1,47 @@
+import avalon.io as io
+import avalon.api
+
+
+def is_latest(representation):
+    """Return whether the representation is from latest version
+
+    Args:
+        representation (str or io.ObjectId): The representation id.
+
+    Returns:
+        bool: Whether the representation is of latest version.
+
+    """
+
+    rep = io.find_one({"_id": io.ObjectId(representation),
+                       "type": "representation"})
+    version = io.find_one({"_id": rep['parent']})
+
+    # Store the highest available version so the model can know
+    # whether current version is currently up-to-date.
+    highest_version = io.find_one({
+        "type": "version",
+        "parent": version["parent"]
+    }, sort=[("name", -1)])
+
+    if version['name'] != highest_version['name']:
+        return True
+    else:
+        return False
+
+
+def any_outdated():
+    """Return whether the current scene has any outdated content"""
+
+    checked = set()
+    host = avalon.api.registered_host()
+    for container in host.ls():
+        representation = container['representation']
+        if representation in checked:
+            continue
+
+        if not is_latest(container['representation']):
+            return True
+
+        checked.add(representation)
+    return False

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -17,8 +17,7 @@ def is_latest(representation):
                        "type": "representation"})
     version = io.find_one({"_id": rep['parent']})
 
-    # Store the highest available version so the model can know
-    # whether current version is currently up-to-date.
+    # Get highest version under the parent
     highest_version = io.find_one({
         "type": "version",
         "parent": version["parent"]

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -32,6 +32,7 @@ def install():
     log.info("Installing callbacks ... ")
     avalon.on("init", on_init)
     avalon.on("save", on_save)
+    avalon.on("open", on_open)
 
 
 def uninstall():
@@ -91,3 +92,36 @@ def on_save(_):
     nodes = lib.get_id_required_nodes(referenced_nodes=False)
     for node, new_id in lib.generate_ids(nodes):
         lib.set_id(node, new_id, overwrite=False)
+
+
+def on_open(_):
+    """On scene open let's assume the containers have changed."""
+
+    from ..lib import any_outdated
+    from avalon.vendor.Qt import QtWidgets
+    from ..widgets import popup
+
+    if any_outdated():
+        log.warning("Scene has outdated content.")
+
+        # Find maya main window
+        top_level_widgets = {w.objectName(): w for w in
+                             QtWidgets.QApplication.topLevelWidgets()}
+        parent = top_level_widgets.get("MayaWindow", None)
+
+        if parent is None:
+            log.info("Skipping outdated content pop-up "
+                     "because Maya window can't be found.")
+        else:
+
+            # Show outdated pop-up
+            def _on_show_inventory():
+                import avalon.tools.cbsceneinventory as tool
+                tool.show(parent=parent)
+
+            dialog = popup.Popup(parent=parent)
+            dialog.setWindowTitle("Maya scene has outdated content")
+            dialog.setMessage("There are outdated containers in "
+                              "your Maya scene.")
+            dialog.on_show.connect(_on_show_inventory)
+            dialog.show()

--- a/colorbleed/widgets/popup.py
+++ b/colorbleed/widgets/popup.py
@@ -1,0 +1,119 @@
+import sys
+import logging
+import contextlib
+
+
+from avalon.vendor.Qt import QtCore, QtWidgets, QtGui
+
+log = logging.getLogger(__name__)
+
+
+class Popup(QtWidgets.QDialog):
+
+    on_show = QtCore.Signal()
+
+    def __init__(self, parent=None, *args, **kwargs):
+        super(Popup, self).__init__(parent=parent, *args, **kwargs)
+        self.setContentsMargins(0, 0, 0, 0)
+
+        # Layout
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(10, 5, 10, 10)
+        message = QtWidgets.QLabel("")
+        message.setStyleSheet("""
+        QLabel {
+            font-size: 12px;
+        }
+        """)
+        show = QtWidgets.QPushButton("Show")
+        show.setSizePolicy(QtWidgets.QSizePolicy.Maximum,
+                           QtWidgets.QSizePolicy.Maximum)
+        show.setStyleSheet("""QPushButton { background-color: #BB0000 }""")
+
+
+        layout.addWidget(message)
+        layout.addWidget(show)
+
+        # Size
+        self.resize(400, 40)
+        geometry = self.calculate_window_geometry()
+        self.setGeometry(geometry)
+
+        self.widgets = {
+            "message": message,
+            "show": show,
+        }
+
+        # Signals
+        show.clicked.connect(self._on_show_clicked)
+
+        # Set default title
+        self.setWindowTitle("Popup")
+
+    def setMessage(self, message):
+        self.widgets['message'].setText(message)
+
+    def _on_show_clicked(self):
+        """Callback for when the 'show' button is clicked.
+
+        Raises the parent (if any)
+
+        """
+
+        parent = self.parent()
+        self.close()
+
+        # Trigger the signal
+        self.on_show.emit()
+
+        if parent:
+            parent.raise_()
+
+    def calculate_window_geometry(self):
+        """Respond to status changes
+
+        On creation, align window with screen bottom right.
+
+        """
+
+        window = self
+
+        width = window.width()
+        width = max(width, window.minimumWidth())
+
+        height = window.height()
+        height = max(height, window.sizeHint().height())
+
+        desktop_geometry = QtWidgets.QDesktopWidget().availableGeometry()
+        screen_geometry = window.geometry()
+
+        screen_width = screen_geometry.width()
+        screen_height = screen_geometry.height()
+
+        # Calculate width and height of system tray
+        systray_width = screen_geometry.width() - desktop_geometry.width()
+        systray_height = screen_geometry.height() - desktop_geometry.height()
+
+        padding = 10
+
+        x = screen_width - width
+        y = screen_height - height
+
+        x -= systray_width + padding
+        y -= systray_height + padding
+
+        return QtCore.QRect(x, y, width, height)
+
+
+@contextlib.contextmanager
+def application():
+    app = QtWidgets.QApplication(sys.argv)
+    yield
+    app.exec_()
+
+
+if __name__ == "__main__":
+    with application():
+        dialog = Popup()
+        dialog.setMessage("There are outdated containers in your Maya scene.")
+        dialog.show()


### PR DESCRIPTION
This is a working but draft implementation for PLN-10. 

I'm not to happy by the amount of required code for this but the usability is alright - also note the popup widget that I added for this. I'm expecting this pop-up or a similar method of highlighting that something is outdated will become used across multiple hosts, e.g. Fusion. That's why I chose *not* to show it somewhere *in* Maya's interface.

This will show a pop-up parented to the Maya host in the bottom right corner after scene open, like this:
![popup](https://user-images.githubusercontent.com/2439881/32440233-99f45a78-c2f2-11e7-9497-998d37c56573.png)

- Pressing the "show" button will open the scene inventory and thus highlight what's outdated. 
- Pressing the "X" or escape will close the popup.

Let's discuss.

---

This will require: https://github.com/getavalon/core/pull/296