### PR TITLE
Implementation of active instance for Pyblish

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_instances.py
+++ b/colorbleed/plugins/maya/publish/collect_instances.py
@@ -81,8 +81,12 @@ class CollectInstances(pyblish.api.ContextPlugin):
                     # are considered non-essential to this
                     # particular publishing pipeline.
                     value = None
-
                 data[attr] = value
+
+            # temporarily translation of `active` to `publish` till issue has
+            # been resolved, https://github.com/pyblish/pyblish-base/issues/307
+            if "active" in data:
+                data["publish"] = data["active"]
 
             # Collect members
             members = cmds.ls(members, long=True) or []


### PR DESCRIPTION
Translating `active` to `publish` due to Pyblish logic