### PR TITLE
Improved collect_setdress

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_setdress.py
+++ b/colorbleed/plugins/maya/publish/collect_setdress.py
@@ -40,7 +40,7 @@ class CollectSetDress(pyblish.api.InstancePlugin):
         for container in containers:
 
             root = lib.get_container_transforms(container, root=True)
-            if root not in instance_lookup:
+            if not root or root not in instance_lookup:
                 continue
 
             # Retrieve the hierarchy


### PR DESCRIPTION
If no root node is found continue with the iteration, this enables it for lookdev to be present in the scene.