### PR TITLE
Implement RIG-3 and other fixes/cleanup

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -357,6 +357,11 @@ def reset_polySelectConstraint(reset=True):
 
     try:
         if reset:
+            # Ensure command is available in mel
+            # This can happen when running standalone
+            if not mel.eval("exists resetPolySelectConstraint"):
+                mel.eval("source polygonConstraint")
+
             # Reset all parameters
             mel.eval("resetPolySelectConstraint;")
         cmds.polySelectConstraint(disable=True)

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1030,7 +1030,7 @@ def get_isolate_view_sets():
     """
 
     view_sets = set()
-    for panel in cmds.getPanel(type="modelPanel"):
+    for panel in cmds.getPanel(type="modelPanel") or []:
         view_set = cmds.modelEditor(panel, query=True, viewObjects=True)
         if view_set:
             view_sets.add(view_set)

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -6,7 +6,7 @@ from avalon import maya, api
 import colorbleed.maya.lib as lib
 
 
-class CollectMindbenderMayaRenderlayers(pyblish.api.ContextPlugin):
+class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
     """Gather instances by active render layers"""
 
     order = pyblish.api.CollectorOrder

--- a/colorbleed/plugins/maya/publish/validate_rig_controllers.py
+++ b/colorbleed/plugins/maya/publish/validate_rig_controllers.py
@@ -181,15 +181,6 @@ class ValidateRigControllers(pyblish.api.InstancePlugin):
                     cls.log.info("Locking visibility for %s" % control)
                     cmds.setAttr(attr, lock=True)
 
-                # Reset non-default values
-                invalid_plugs = cls.get_non_default_attributes(control)
-                if invalid_plugs:
-                    for plug in invalid_plugs:
-                        attr = plug.split(".")[-1]
-                        default = cls.CONTROLLER_DEFAULTS[attr]
-                        cls.log.info("Setting %s to %s" % (plug, default))
-                        cmds.setAttr(plug, default)
-
                 # Remove incoming connections
                 invalid_plugs = cls.get_connected_attributes(control)
                 if invalid_plugs:
@@ -200,3 +191,12 @@ class ValidateRigControllers(pyblish.api.InstancePlugin):
                                                       destination=False,
                                                       plugs=True)[0]
                         cmds.disconnectAttr(source, plug)
+
+                # Reset non-default values
+                invalid_plugs = cls.get_non_default_attributes(control)
+                if invalid_plugs:
+                    for plug in invalid_plugs:
+                        attr = plug.split(".")[-1]
+                        default = cls.CONTROLLER_DEFAULTS[attr]
+                        cls.log.info("Setting %s to %s" % (plug, default))
+                        cmds.setAttr(plug, default)

--- a/colorbleed/plugins/maya/publish/validate_rig_controllers.py
+++ b/colorbleed/plugins/maya/publish/validate_rig_controllers.py
@@ -81,11 +81,12 @@ class ValidateRigControllers(pyblish.api.InstancePlugin):
                 has_non_default_values.append(control)
 
         if has_connections:
-            cls.log.error("Controls have keys: %s" % has_connections)
+            cls.log.error("Controls have input connections: "
+                          "%s" % has_connections)
 
         if has_non_default_values:
-            cls.log.error("Controls have invalid attribute "
-                          "values: %s" % has_non_default_values)
+            cls.log.error("Controls have non-default values: "
+                          "%s" % has_non_default_values)
 
         if has_unlocked_visibility:
             cls.log.error("Controls have unlocked visibility "

--- a/colorbleed/plugins/maya/publish/validate_rig_controllers.py
+++ b/colorbleed/plugins/maya/publish/validate_rig_controllers.py
@@ -30,12 +30,6 @@ class ValidateRigControllers(pyblish.api.InstancePlugin):
     actions = [colorbleed.api.RepairAction,
                colorbleed.api.SelectInvalidAction]
 
-    def process(self, instance):
-        invalid = self.get_invalid(instance)
-        if invalid:
-            raise RuntimeError('{} failed, see log '
-                               'information'.format(self.label))
-
     # Default controller values
     CONTROLLER_DEFAULTS = {
         "translateX": 0,
@@ -48,6 +42,12 @@ class ValidateRigControllers(pyblish.api.InstancePlugin):
         "scaleY": 1,
         "scaleZ": 1
     }
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise RuntimeError('{} failed, see log '
+                               'information'.format(self.label))
 
     @classmethod
     def get_invalid(cls, instance):

--- a/colorbleed/plugins/maya/publish/validate_setdress_namespaces.py
+++ b/colorbleed/plugins/maya/publish/validate_setdress_namespaces.py
@@ -1,5 +1,5 @@
 import pyblish.api
-from collection import defaultdict
+from collections import defaultdict
 
 
 class ValidateSetdressNamespaces(pyblish.api.InstancePlugin):


### PR DESCRIPTION
- Implement RIG-3: Controls will now only be validated on incoming connections and default values for unlocked attributes (and locked attributes are ignored)
- Fix the validate_setdress_namespaces that was ignored previously because of a typo in the import
- Fix `maya.cmds.listSets` returning internal objects (that are not maya nodes available to maya commands) in look collector
- Fix `resetPolySelectConstraint` not being available in Maya batch mode
- Fix `getPanel` returning None in batch mode.