### PR TITLE
Update Yeti Cache Loader

### DIFF
--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -71,7 +71,7 @@ class YetiCacheLoader(api.Loader):
             settings.pop("cbId", None)
 
             # Apply new colorbleed ID to transform node
-            # TODO: get ID from transfrom in data to ensure consistency
+            # TODO: get ID from transform in data to ensure consistency
             _ids = lib.generate_ids(nodes=[transform_node], asset_id=asset_id)
             for n, _id in _ids:
                 lib.set_id(n, unique_id=_id)

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -144,8 +144,7 @@ class YetiCacheLoader(api.Loader):
 
         path = api.get_representation_path(representation)
         members = cmds.sets(container['objectName'], query=True)
-        all_members = cmds.listRelatives(members, ad=True)
-        yeti_node = cmds.ls(all_members, type="pgYetiMaya", long=True)
+        yeti_node = cmds.ls(members, type="pgYetiMaya", long=True)
 
         for node in yeti_node:
             node_name = node.split(":")[-1]

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -71,6 +71,7 @@ class YetiCacheLoader(api.Loader):
             settings.pop("cbId", None)
 
             # Apply new colorbleed ID to transform node
+            # TODO: get ID from transfrom in data to ensure consistency
             _ids = lib.generate_ids(nodes=[transform_node], asset_id=asset_id)
             for n, _id in _ids:
                 lib.set_id(n, unique_id=_id)
@@ -89,7 +90,7 @@ class YetiCacheLoader(api.Loader):
             cache_fname = self.validate_cache(cache)
             cache_path = os.path.join(self.fname, cache_fname)
 
-            # Preset the viewport density]
+            # Preset the viewport density
             cmds.setAttr("%s.viewportDensity" % yeti_node, 0.1)
 
             # Add filename to `cacheFileName` attribute
@@ -104,7 +105,7 @@ class YetiCacheLoader(api.Loader):
             # Set verbosity for debug purposes
             cmds.setAttr("%s.verbosity" % yeti_node, 2)
 
-            # Enable the cache by setting the fil mode
+            # Enable the cache by setting the file mode
             cmds.setAttr("%s.fileMode" % yeti_node, 1)
 
             nodes.append(yeti_node)

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -89,18 +89,23 @@ class YetiCacheLoader(api.Loader):
             cache_fname = self.validate_cache(cache)
             cache_path = os.path.join(self.fname, cache_fname)
 
-            # Add filename to `cacheFileName` attribute, set to cache mode
+            # Preset the viewport density]
+            cmds.setAttr("%s.viewportDensity" % yeti_node, 0.1)
+
+            # Add filename to `cacheFileName` attribute
             cmds.setAttr("%s.cacheFileName" % yeti_node,
                          cache_path,
                          type="string")
-            # Set file mode to cache
-            cmds.setAttr("%s.fileMode" % yeti_node, 1)
+
             cmds.setAttr("%s.imageSearchPath" % yeti_node,
                          image_search_path,
                          type="string")
 
             # Set verbosity for debug purposes
             cmds.setAttr("%s.verbosity" % yeti_node, 2)
+
+            # Enable the cache by setting the fil mode
+            cmds.setAttr("%s.fileMode" % yeti_node, 1)
 
             nodes.append(yeti_node)
             nodes.append(transform_node)

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -110,7 +110,6 @@ class YetiCacheLoader(api.Loader):
             nodes.append(yeti_node)
             nodes.append(transform_node)
 
-
         group_name = "{}:{}".format(namespace, asset["name"])
         group_node = cmds.group(nodes, name=group_name)
 


### PR DESCRIPTION
Ensure loaded cache does not kill Maya, dropped viewport density from 1.0 to 0.1 by default
Loader now adds the shape nodes to the container explicitly
Loader now adds cbId to transform nodes, these were missing