### PR TITLE
Updated collect data & related logic

### DIFF
--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -46,13 +46,16 @@ class YetiCacheLoader(api.Loader):
             image_search_path = os.path.normpath(resource_folder)
 
         # Get node name from JSON
-        nodes = []
         if "nodes" in fursettings:
             node_data = fursettings["nodes"]
-            self.create_nodes(namespace, image_search_path, node_data)
+            nodes = self.create_nodes(namespace, image_search_path, node_data)
         else:
             # Backwards compatibilty
-            self.create_nodes_old(namespace, image_search_path, fursettings)
+            self.log.info("Encountered old data, "
+                          "using backwards compatibility")
+            nodes = self.create_nodes_old(namespace,
+                                          image_search_path,
+                                          fursettings)
 
         group_name = "{}:{}".format(namespace, asset["name"])
         group_node = cmds.group(nodes, name=group_name)
@@ -241,13 +244,13 @@ class YetiCacheLoader(api.Loader):
             cmds.connectAttr("time1.outTime", "%s.currentTime" % yeti_node)
 
             # Apply explicit colorbleed ID to node
-            shape_id = settings["cbId"]
+            shape_id = node_settings["cbId"]
             asset_id = shape_id.split(":", 1)[0]
 
             lib.set_id(node=yeti_node,
                        unique_id=shape_id,
                        overwrite=True)
-            settings.pop("cbId", None)
+            node_settings.pop("cbId", None)
 
             # Apply new colorbleed ID to transform node
             # TODO: get ID from transform in data to ensure consistency
@@ -256,7 +259,7 @@ class YetiCacheLoader(api.Loader):
                 lib.set_id(n, unique_id=_id)
 
             # Apply settings
-            for attr, value in settings.items():
+            for attr, value in node_settings.items():
                 attribute = "%s.%s" % (yeti_node, attr)
                 cmds.setAttr(attribute, value)
 

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -58,8 +58,10 @@ class YetiCacheLoader(api.Loader):
             lib.set_id(transform_node, transform["cbId"])
 
             # Create pgYetiMaya node
+            original_node = node_settings["name"]
+            node_name = "{}:{}".format(namespace, original_node)
             yeti_node = cmds.createNode("pgYetiMaya",
-                                        name=node_settings["name"],
+                                        name=node_name,
                                         parent=transform_node)
 
             lib.set_id(yeti_node, node_settings["cbId"])
@@ -77,7 +79,7 @@ class YetiCacheLoader(api.Loader):
                 cmds.setAttr(attribute, value, **kwargs)
 
             # Ensure the node has no namespace identifiers
-            node_name = yeti_node.replace(":", "_")
+            node_name = original_node.replace(":", "_")
 
             # Create full cache path
             cache = os.path.join(self.fname, "{}.%04d.fur".format(node_name))

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -38,24 +38,13 @@ class YetiCacheLoader(api.Loader):
             fursettings = json.load(fp)
 
         # Check if resources map exists
-        # TODO: should be stored in fursettings
-        image_search_path = ""
-        version_folder = os.path.dirname(self.fname)
-        resource_folder = os.path.join(version_folder, "resources")
-        if os.path.exists(resource_folder):
-            image_search_path = os.path.normpath(resource_folder)
-
         # Get node name from JSON
-        if "nodes" in fursettings:
-            node_data = fursettings["nodes"]
-            nodes = self.create_nodes(namespace, image_search_path, node_data)
-        else:
-            # Backwards compatibilty
-            self.log.info("Encountered old data, "
-                          "using backwards compatibility")
-            nodes = self.create_nodes_old(namespace,
-                                          image_search_path,
-                                          fursettings)
+        if "nodes" not in fursettings:
+            raise RuntimeError("Encountered invalid data, expect 'nodes' in "
+                               "fursettings.")
+
+        node_data = fursettings["nodes"]
+        nodes = self.create_nodes(namespace, node_data)
 
         group_name = "{}:{}".format(namespace, asset["name"])
         group_node = cmds.group(nodes, name=group_name)
@@ -148,7 +137,7 @@ class YetiCacheLoader(api.Loader):
 
         return filename
 
-    def create_nodes(self, namespace, image_search_path, settings):
+    def create_nodes(self, namespace, settings):
 
         # Get node name from JSON
         nodes = []
@@ -156,8 +145,8 @@ class YetiCacheLoader(api.Loader):
 
             # Create transform node
             transform = node_settings["transform"]
-            transform_node = cmds.createNode("transform",
-                                             name=transform["name"])
+            transform_name = "{}:{}".format(namespace, transform["name"])
+            transform_node = cmds.createNode("transform", name=transform_name)
 
             lib.set_id(transform_node, transform["cbId"])
 
@@ -197,91 +186,6 @@ class YetiCacheLoader(api.Loader):
             # Add filename to `cacheFileName` attribute
             cmds.setAttr("%s.cacheFileName" % yeti_node,
                          cache_path,
-                         type="string")
-
-            cmds.setAttr("%s.imageSearchPath" % yeti_node,
-                         image_search_path,
-                         type="string")
-
-            # Set verbosity for debug purposes
-            cmds.setAttr("%s.verbosity" % yeti_node, 2)
-
-            # Enable the cache by setting the file mode
-            cmds.setAttr("%s.fileMode" % yeti_node, 1)
-
-            nodes.append(yeti_node)
-            nodes.append(transform_node)
-
-        return nodes
-
-    def create_nodes_old(self, namespace, image_search_path, settings):
-        """Create nodes with the old logic
-
-        Support previously published assets
-
-        Args:
-            namespace(str): unique name to identify the nodes
-            image_search_path (str): directory path to textures
-            settings(dict): collection of node names with settings
-        Returns:
-            list: all created pgYetiMaya nodes and their transforms
-
-        """
-
-        nodes = []
-        for node, node_settings in settings.items():
-
-            # Create transform
-            transform_name = "{}:{}".format(namespace, node.split("Shape")[0])
-            transform_node = cmds.createNode("transform", name=transform_name)
-
-            # Create new pgYetiMaya node
-            node_name = "{}:{}".format(namespace, node)
-            yeti_node = cmds.createNode("pgYetiMaya",
-                                        name=node_name,
-                                        parent=transform_node)
-
-            cmds.connectAttr("time1.outTime", "%s.currentTime" % yeti_node)
-
-            # Apply explicit colorbleed ID to node
-            shape_id = node_settings["cbId"]
-            asset_id = shape_id.split(":", 1)[0]
-
-            lib.set_id(node=yeti_node,
-                       unique_id=shape_id,
-                       overwrite=True)
-            node_settings.pop("cbId", None)
-
-            # Apply new colorbleed ID to transform node
-            # TODO: get ID from transform in data to ensure consistency
-            _ids = lib.generate_ids(nodes=[transform_node], asset_id=asset_id)
-            for n, _id in _ids:
-                lib.set_id(n, unique_id=_id)
-
-            # Apply settings
-            for attr, value in node_settings.items():
-                attribute = "%s.%s" % (yeti_node, attr)
-                cmds.setAttr(attribute, value)
-
-            # Ensure the node has no namespace identifiers
-            node = node.replace(":", "_")
-
-            # Create full cache path
-            cache = os.path.join(self.fname, "{}.%04d.fur".format(node))
-            cache = os.path.normpath(cache)
-            cache_fname = self.validate_cache(cache)
-            cache_path = os.path.join(self.fname, cache_fname)
-
-            # Preset the viewport density
-            cmds.setAttr("%s.viewportDensity" % yeti_node, 0.1)
-
-            # Add filename to `cacheFileName` attribute
-            cmds.setAttr("%s.cacheFileName" % yeti_node,
-                         cache_path,
-                         type="string")
-
-            cmds.setAttr("%s.imageSearchPath" % yeti_node,
-                         image_search_path,
                          type="string")
 
             # Set verbosity for debug purposes

--- a/colorbleed/plugins/maya/publish/collect_look.py
+++ b/colorbleed/plugins/maya/publish/collect_look.py
@@ -27,8 +27,12 @@ def get_look_attrs(node):
 
     """
 
+    # When referenced get only attributes that are "changed since file open"
+    # which includes any reference edits, otherwise take *all* user defined
+    # attributes
+    is_referenced = cmds.referenceQuery(node, isNodeReferenced=True)
     result = cmds.listAttr(node, userDefined=True,
-                           changedSinceFileOpen=True) or []
+                           changedSinceFileOpen=is_referenced) or []
 
     # `cbId` is added when a scene is saved, ignore by default
     if "cbId" in result:
@@ -91,7 +95,7 @@ class CollectLook(pyblish.api.InstancePlugin):
         for objset in list(sets):
             self.log.debug("From %s.." % objset)
 
-            # Get all nodes of the current objectSet
+            # Get all nodes of the current objectSet (shadingEngine)
             for member in cmds.ls(cmds.sets(objset, query=True), long=True):
                 member_data = self.collect_member_data(member,
                                                        instance_lookup)

--- a/colorbleed/plugins/maya/publish/collect_yeti_cache.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_cache.py
@@ -2,6 +2,7 @@ from maya import cmds
 
 import pyblish.api
 
+from colorbleed.maya import lib
 
 SETTINGS = {"renderDensity",
             "renderWidth",
@@ -22,11 +23,28 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
     def process(self, instance):
 
         # Collect fur settings
-        settings = {}
-        for node in cmds.ls(instance, type="pgYetiMaya"):
-            settings[node] = {}
+        settings = {"nodes": []}
+
+        # Get yeti nodes and their transforms
+        yeti_shapes = cmds.ls(instance, type="pgYetiMaya")
+
+        for shape in yeti_shapes:
+            shape_data = {"transform": None,
+                          "name": shape}
+
+            # Get specific node attributes
             for attr in SETTINGS:
-                current = cmds.getAttr("%s.%s" % (node, attr))
-                settings[node][attr] = current
+                current = cmds.getAttr("%s.%s" % (shape, attr))
+                shape_data[attr] = current
+
+            # Get transform data
+            parent = cmds.listRelatives(shape, parent=True)[0]
+            transform_data = {"name": parent,
+                              "cbId": lib.get_id(parent)}
+
+            # Store transform data
+            shape_data["transform"] = transform_data
+
+            settings["nodes"].append(shape_data)
 
         instance.data["fursettings"] = settings

--- a/colorbleed/plugins/maya/publish/collect_yeti_cache.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_cache.py
@@ -8,11 +8,23 @@ SETTINGS = {"renderDensity",
             "renderWidth",
             "renderLength",
             "increaseRenderBounds",
+            "imageSearchPath",
             "cbId"}
 
 
 class CollectYetiCache(pyblish.api.InstancePlugin):
-    """Collect all information of the Yeti caches"""
+    """Collect all information of the Yeti caches
+
+    The information contains the following attributes per Yeti node
+
+    - "renderDensity"
+    - "renderWidth"
+    - "renderLength"
+    - "increaseRenderBounds"
+    - "imageSearchPath"
+
+    Other information is the name of the transform and it's Colorbleed ID
+    """
 
     order = pyblish.api.CollectorOrder + 0.45
     label = "Collect Yeti Cache"
@@ -27,22 +39,24 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
 
         # Get yeti nodes and their transforms
         yeti_shapes = cmds.ls(instance, type="pgYetiMaya")
-
         for shape in yeti_shapes:
             shape_data = {"transform": None,
-                          "name": shape}
+                          "name": shape,
+                          "cbId": lib.get_id(shape),
+                          "attrs": None}
 
             # Get specific node attributes
+            attr_data = {}
             for attr in SETTINGS:
                 current = cmds.getAttr("%s.%s" % (shape, attr))
-                shape_data[attr] = current
+                attr_data[attr] = current
 
             # Get transform data
             parent = cmds.listRelatives(shape, parent=True)[0]
-            transform_data = {"name": parent,
-                              "cbId": lib.get_id(parent)}
+            transform_data = {"name": parent, "cbId": lib.get_id(parent)}
 
-            # Store transform data
+            # Store collected data
+            shape_data["attrs"] = attr_data
             shape_data["transform"] = transform_data
 
             settings["nodes"].append(shape_data)

--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -57,8 +57,8 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
 
             # The plug must go in the socket, remember this for the loader
             inputs.append({"connections": [src_attr, dest_attr],
-                           "plugID": lib.get_id(dest_node),
-                           "socketID": lib.get_id(src_node)})
+                           "destinationID": lib.get_id(dest_node),
+                           "sourceID": lib.get_id(src_node)})
 
         # Collect any textures if used
         yeti_resources = []

--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -37,28 +37,30 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
                                          fullPath=True) or input_content
 
         # Get all the shapes
-        input_shapes = cmds.ls(input_nodes, long=True)
+        input_shapes = cmds.ls(input_nodes, long=True, noIntermediate=True)
 
         # Store all connections
+        print "input shape:", input_shapes
         connections = cmds.listConnections(input_shapes,
                                            source=True,
                                            destination=False,
                                            connections=True,
                                            plugs=True) or []
 
-        # Group per source, destination pair
-        grouped = [(item, connections[i+1]) for i, item in
+        # Group per source, destination pair. We need to reverse the connection
+        # list as it comes in with the shape used to query first while that
+        # shape is the destination of the connection
+        grouped = [(connections[i+1], item) for i, item in
                    enumerate(connections) if i % 2 == 0]
 
         inputs = []
         for src, dest in grouped:
-            src_node, src_attr = src.split(".", 1)
+            source_node, source_attr = src.split(".", 1)
             dest_node, dest_attr = dest.split(".", 1)
 
-            # The plug must go in the socket, remember this for the loader
-            inputs.append({"connections": [src_attr, dest_attr],
-                           "destinationID": lib.get_id(dest_node),
-                           "sourceID": lib.get_id(src_node)})
+            inputs.append({"connections": [source_attr, dest_attr],
+                           "sourceID": lib.get_id(source_node),
+                           "destinationID": lib.get_id(dest_node)})
 
         # Collect any textures if used
         yeti_resources = []

--- a/colorbleed/plugins/maya/publish/extract_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/extract_yeti_rig.py
@@ -18,7 +18,7 @@ def disconnected_attributes(settings, members):
         for input in settings["inputs"]:
 
             # get source
-            socket_id = input["socketID"]
+            socket_id = input["sourceId"]
             sources = lib.lsattr("cbId", socket_id)
             sources = [i for i in sources if
                        not cmds.referenceQuery(i, isNodeReferenced=True)
@@ -26,7 +26,7 @@ def disconnected_attributes(settings, members):
             src = sources[0]
 
             # get destination
-            plug_id = input["plugID"]
+            plug_id = input["destinationID"]
             plugs = lib.lsattr("cbId", plug_id)
             destinations = [i for i in plugs if i not in members and
                             i not in sources]

--- a/colorbleed/plugins/maya/publish/extract_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/extract_yeti_rig.py
@@ -17,31 +17,29 @@ def disconnected_attributes(settings, members):
     try:
         for input in settings["inputs"]:
 
-            # get source
-            socket_id = input["sourceId"]
-            sources = lib.lsattr("cbId", socket_id)
-            sources = [i for i in sources if
+            # Get source shapes
+            source_nodes = lib.lsattr("cbId", input["sourceID"])
+            sources = [i for i in source_nodes if
                        not cmds.referenceQuery(i, isNodeReferenced=True)
                        and i in members]
-            src = sources[0]
+            source = sources[0]
 
-            # get destination
-            plug_id = input["destinationID"]
-            plugs = lib.lsattr("cbId", plug_id)
-            destinations = [i for i in plugs if i not in members and
-                            i not in sources]
-            dst = destinations[0]
+            # Get destination shapes (the shapes used as hook up)
+            destination_nodes = lib.lsattr("cbId", input["destinationID"])
+            destinations = [i for i in destination_nodes if i not in members
+                            and i not in sources]
+            destination = destinations[0]
 
-            # break connection
+            # Break connection
             connections = input["connections"]
-            src_attribute = "%s.%s" % (src, connections[0])
-            dst_attribute = "%s.%s" % (dst, connections[1])
+            src_attribute = "%s.%s" % (source, connections[0])
+            dst_attribute = "%s.%s" % (destination, connections[1])
 
             # store connection pair
-            if not cmds.isConnected(dst_attribute, src_attribute):
+            if not cmds.isConnected(src_attribute, dst_attribute):
                 continue
 
-            cmds.disconnectAttr(dst_attribute, src_attribute)
+            cmds.disconnectAttr(src_attribute, dst_attribute)
             original_connection.append([src_attribute, dst_attribute])
         yield
     finally:


### PR DESCRIPTION
Yeti:
* Added transform information (node ID and name)
* Attributes of shape node are stored in their own key,  `"attrs": {attr: value, attr: value}`
* Updated loading logic to match new data structure

Look:
* Collect all user attributes of nodes with ID which are not referenced within an instance

This will allow the current approach of loading Yeti caches in lookdev to have objectIDs for compositing / rendering.