### PR TITLE
Improve versioning logic and move the versioning logic to lib.py

### DIFF
--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -1,3 +1,5 @@
+import os
+import re
 import logging
 
 from .vendor import pather
@@ -90,3 +92,55 @@ def update_task_from_path(path):
     if changes:
         log.info("Updating work task to: %s", context)
         avalon.api.update_current_task(**changes)
+
+
+def _rreplace(s, a, b, n=1):
+    """Replace a with b in string s from right side n times"""
+    return b.join(s.rsplit(a, n))
+
+
+def version_up(filepath):
+    """Version up filepath to a new non-existing version.
+
+    Parses for a version identifier like `_v001` or `.v001`
+    When no version present _v001 is appended as suffix.
+
+    Returns:
+        str: filepath with increased version number
+
+    """
+
+    dirname = os.path.dirname(filepath)
+    basename, ext = os.path.splitext(os.path.basename(filepath))
+
+    regex = "[._]v\d+"
+    matches = re.findall(regex, str(basename), re.IGNORECASE)
+    if not matches:
+        log.info("Creating version...")
+        new_label = "_v{version:03d}".format(version=1)
+        new_basename = "{}{}".format(basename, new_label)
+    else:
+        label = matches[-1]
+        version = re.search("\d+", label).group()
+        padding = len(version)
+
+        new_version = int(version) + 1
+        new_version = '{version:0{padding}d}'.format(version=new_version,
+                                                     padding=padding)
+        new_label = label.replace(version, new_version, 1)
+        new_basename = _rreplace(basename, label, new_label)
+
+    new_filename = "{}{}".format(new_basename, ext)
+    new_filename = os.path.join(dirname, new_filename)
+    new_filename = os.path.normpath(new_filename)
+
+    if new_filename == filepath:
+        raise RuntimeError("Created path is the same as current file,"
+                           "this is a bug")
+
+    if os.path.exists(new_filename):
+        log.info("Skipping existing version %s" % new_label)
+        return version_up(new_filename)
+
+    log.info("New version %s" % new_label)
+    return new_filename

--- a/colorbleed/plugins/maya/publish/increment_current_file_deadline.py
+++ b/colorbleed/plugins/maya/publish/increment_current_file_deadline.py
@@ -2,10 +2,9 @@ import pyblish.api
 
 
 class IncrementCurrentFileDeadline(pyblish.api.ContextPlugin):
-    """Submit available render layers to Deadline
+    """Increment the current file.
 
-    Renders are submitted to a Deadline Web Service as
-    supplied via the environment variable AVALON_DEADLINE
+    Saves the current maya scene with an increased version number.
 
     """
 
@@ -17,60 +16,24 @@ class IncrementCurrentFileDeadline(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
+        import os
         from maya import cmds
-
+        from colorbleed.lib import version_up
         from colorbleed.action import get_errored_plugins_from_data
 
-        plugins = get_errored_plugins_from_data(context)
-
+        errored_plugins = get_errored_plugins_from_data(context)
         if any(plugin.__name__ == "MindbenderSubmitDeadline"
-                for plugin in plugins):
+                for plugin in errored_plugins):
             raise RuntimeError("Skipping incrementing current file because "
                                "submission to deadline failed.")
 
-        new_filename = self.version_up(context.data["currentFile"])
+        current_filepath = context.data["currentFile"]
+        new_filepath = version_up(current_filepath)
 
-        cmds.file(rename=new_filename)
+        # Ensure the suffix is .ma because we're saving to `mayaAscii` type
+        if not new_filepath.endswith(".ma"):
+            self.log.warning("Refactoring scene to .ma extension")
+            new_filepath = os.path.splitext(new_filepath)[0] + ".ma"
+
+        cmds.file(rename=new_filepath)
         cmds.file(save=True, force=True, type="mayaAscii")
-
-    def version_up(self, filepath):
-
-        import os
-        import re
-
-        dirname = os.path.dirname(filepath)
-        basename, ext = os.path.splitext(os.path.basename(filepath))
-
-        regex = "[/_.]" + "v" + "\d+"
-        matches = re.findall(regex, str(basename), re.IGNORECASE)
-        if not len(matches):
-            self.log.info("Creating version ...")
-            version_str = "_v{number:03d}".format(number=1)
-        else:
-            version_label = matches[-1:][0]
-            basename = basename.strip(version_label)
-
-            current_version = re.search("\d+", version_label).group()
-            padding = len(current_version)
-            prefix = version_label.split(current_version)[0]
-
-            version_int = int(current_version) + 1
-            version_str = '{prefix}{number:0{padding}d}'.format(
-                                                        prefix=prefix,
-                                                        padding=padding,
-                                                        number=version_int)
-        # Create new basename
-        self.log.info("New version %s" % version_str)
-        new_basename = "{}{}{}".format(basename, version_str, ext)
-
-        new_filename = os.path.join(dirname, new_basename)
-        new_filename = os.path.normpath(new_filename)
-
-        if new_filename == filepath:
-            raise RuntimeError("Created path is the same as current file,"
-                               "please let someone no")
-
-        if os.path.exists(new_filename):
-            new_filename = self.version_up(new_filename)
-
-        return new_filename


### PR DESCRIPTION
- Improve versioning logic
- Move the versioning logic to lib.py
- Ensure maya scene is saved with `.ma` extension when incrementing to avoid odd "mayaAscii" saved files with different extension (e.g. `.mb`)