### PR TITLE
Solves issue REN-29

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_instances.py
+++ b/colorbleed/plugins/maya/publish/collect_instances.py
@@ -113,11 +113,12 @@ class CollectInstances(pyblish.api.ContextPlugin):
             # user interface interested in visualising it.
             self.log.info("Found: \"%s\" " % instance.data["name"])
 
+        def sort_by_family(instance):
+            """Sort by family"""
+            return instance.data.get("families", instance.data.get("family"))
+
         # Sort/grouped by family (preserving local index)
-        grouped = sorted(enumerate(context), key=self.sorter)
-        context[:] = [x[1] for x in grouped]
-        # context[:] = sorted(context, key= lambda x: (x.data['families'],
-        #                                              x.data['name']))
+        context[:] = sorted(context, key=sort_by_family)
 
         return context
 
@@ -138,10 +139,3 @@ class CollectInstances(pyblish.api.ContextPlugin):
             parents.extend(items)
 
         return list(set(parents))
-
-    def sorter(self, x):
-        """Sort a tuple of index and instance"""
-        index, instance = x
-        family = instance.data.get("families", instance.data.get("family"))
-
-        return family, index

--- a/colorbleed/plugins/maya/publish/collect_instances.py
+++ b/colorbleed/plugins/maya/publish/collect_instances.py
@@ -113,7 +113,11 @@ class CollectInstances(pyblish.api.ContextPlugin):
             # user interface interested in visualising it.
             self.log.info("Found: \"%s\" " % instance.data["name"])
 
-        context[:] = sorted(context)
+        # Sort/grouped by family (preserving local index)
+        grouped = sorted(enumerate(context), key=self.sorter)
+        context[:] = [x[1] for x in grouped]
+        # context[:] = sorted(context, key= lambda x: (x.data['families'],
+        #                                              x.data['name']))
 
         return context
 
@@ -134,3 +138,10 @@ class CollectInstances(pyblish.api.ContextPlugin):
             parents.extend(items)
 
         return list(set(parents))
+
+    def sorter(self, x):
+        """Sort a tuple of index and instance"""
+        index, instance = x
+        family = instance.data.get("families", instance.data.get("family"))
+
+        return family, index

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -39,10 +39,11 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
                         cmds.referenceQuery(i, isNodeReferenced=True)]
 
         # Sort by displayOrder
-        renderlayers = sorted(renderlayers,
-                              key=lambda x: -cmds.getAttr("%s.displayOrder" % x))
+        def sort_by_display_order(layer):
+            return cmds.getAttr("%s.displayOrder" % layer)
 
-        renderlayers = reversed(renderlayers)
+        renderlayers = sorted(renderlayers, key=sort_by_display_order)
+
         if not use_defaultlayer:
             renderlayers = [i for i in renderlayers if
                             not i.endswith("defaultRenderLayer")]

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -12,7 +12,6 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder
     hosts = ["maya"]
     label = "Render Layers"
-    optional = True
 
     def process(self, context):
 
@@ -39,6 +38,11 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
                         cmds.getAttr("{}.renderable".format(i)) and not
                         cmds.referenceQuery(i, isNodeReferenced=True)]
 
+        # Sort by displayOrder
+        renderlayers = sorted(renderlayers,
+                              key=lambda x: -cmds.getAttr("%s.displayOrder" % x))
+
+        renderlayers = reversed(renderlayers)
         if not use_defaultlayer:
             renderlayers = [i for i in renderlayers if
                             not i.endswith("defaultRenderLayer")]

--- a/colorbleed/plugins/maya/publish/validate_look_single_shader.py
+++ b/colorbleed/plugins/maya/publish/validate_look_single_shader.py
@@ -15,6 +15,7 @@ class ValidateSingleShader(pyblish.api.InstancePlugin):
     families = ['colorbleed.look']
     hosts = ['maya']
     label = 'Look Single Shader Per Shape'
+    actions = [colorbleed.api.SelectInvalidAction]
 
     # The default connections to check
     def process(self, instance):


### PR DESCRIPTION
* Group instances based on family not name
* Sort render layers based on the `displayOrder` attribute ( display order as seen in Render Layer Manager )
* Added forgotten select action to `ValidateSingleShader`