### PR TITLE
Fixed PLN-68

### DIFF
--- a/colorbleed/plugins/maya/load/load_camera.py
+++ b/colorbleed/plugins/maya/load/load_camera.py
@@ -27,8 +27,15 @@ class CameraLoader(colorbleed.maya.plugin.ReferenceLoader):
                           returnNewNodes=True)
 
         cameras = cmds.ls(nodes, type="camera")
-        for camera in cameras:
-            cmds.camera(camera, edit=True, lockTransform=True)
+
+        # Check the Maya version, lockTransform has been introduced since
+        # Maya 2017
+        if cmds.about(version=True) >= "2018":
+            for camera in cameras:
+                cmds.camera(camera, edit=True, lockTransform=True)
+        else:
+            self.log.warning("This version of Maya does not support locking of"
+                             " transforms of cameras.")
 
         self[:] = nodes
 


### PR DESCRIPTION
Fixes issue with unable to containerize loaded camera because the `cmds.camera` function does not support `lockTransform` flag. This flag has been introduced in Maya 2017