### PR TITLE
Fix PLN-108 & PLN-109

### DIFF
--- a/colorbleed/maya/plugin.py
+++ b/colorbleed/maya/plugin.py
@@ -39,8 +39,11 @@ class ReferenceLoader(api.Loader):
              namespace=None,
              data=None):
 
+        import os
         from avalon.maya import lib
         from avalon.maya.pipeline import containerise
+
+        assert os.path.exists(self.fname), "%s does not exist." % self.fname
 
         asset = context['asset']
 

--- a/colorbleed/maya/plugin.py
+++ b/colorbleed/maya/plugin.py
@@ -149,7 +149,7 @@ class ReferenceLoader(api.Loader):
             if not content:
                 raise
 
-            self.log.info("Ignoring file read error:\n%s", exc)
+            self.log.warning("Ignoring file read error:\n%s", exc)
 
         # Fix PLN-40 for older containers created with Avalon that had the
         # `.verticesOnlySet` set to True.


### PR DESCRIPTION
Fixes read errors on referenced files and also is more explicit about which reference node to use from the container, it now uses the highest level reference node usually the top node, but could - with this code - still work when the container is also inside a reference and thus is not a top reference node.