### PR TITLE
Fix LKD-20: Don't ignore initialShadingGroup in collection, instead validate it to avoid confusion.

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1080,7 +1080,7 @@ def get_related_sets(node):
     ignore_suffices = ["out_SET", "controls_SET", "_INST", "_CON"]
 
     # Default nodes to ignore
-    defaults = {"initialShadingGroup",  "defaultLightSet", "defaultObjectSet"}
+    defaults = {"defaultLightSet", "defaultObjectSet"}
 
     # Ids to ignore
     ignored = {"pyblish.avalon.instance", "pyblish.avalon.container"}


### PR DESCRIPTION
**Don't ignore default set "initialShadingGroup" in `get_related_sets`**

This allows to collect the default shader too - it's up to the validator to decide whether it's valid to have it, which is a validator we already have in place.