### PR TITLE
Introduce fetching of additional data

### DIFF
--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -1,4 +1,6 @@
 import os
+import importlib
+
 from pyblish import api as pyblish
 from avalon import api as avalon
 
@@ -23,3 +25,36 @@ def uninstall():
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     avalon.deregister_plugin_path(avalon.Loader, LOAD_PATH)
 
+
+def _get_host_name():
+
+    _host = avalon.registered_host()
+    # This covers nested module name like avalon.maya
+    return _host.__name__.rsplit(".", 1)[-1]
+
+
+def collect_container_metadata(container):
+    """Add additional data based on the current host
+
+    If the host application's lib module does not have a function to inject
+    additional data it will return the input container
+
+    Args:
+        container (dict): collection if representation data in host
+
+    Returns:
+        generator
+    """
+
+    host_name = _get_host_name()
+
+    # This will cover nested module names like avalon.maya
+    package_name = "{}.{}.lib".format(__name__, host_name)
+    hostlib = importlib.import_module(package_name)
+
+    if not hasattr(hostlib, "get_additional_data"):
+        print("{} has no function called "
+              "get_additional_data".format(package_name))
+        return container
+
+    return hostlib.get_additional_data(container)

--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -1,5 +1,4 @@
 import os
-import importlib
 
 from pyblish import api as pyblish
 from avalon import api as avalon
@@ -24,37 +23,3 @@ def uninstall():
     print("Deregistering global plug-ins..")
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     avalon.deregister_plugin_path(avalon.Loader, LOAD_PATH)
-
-
-def _get_host_name():
-
-    _host = avalon.registered_host()
-    # This covers nested module name like avalon.maya
-    return _host.__name__.rsplit(".", 1)[-1]
-
-
-def collect_container_metadata(container):
-    """Add additional data based on the current host
-
-    If the host application's lib module does not have a function to inject
-    additional data it will return the input container
-
-    Args:
-        container (dict): collection if representation data in host
-
-    Returns:
-        generator
-    """
-
-    host_name = _get_host_name()
-
-    # This will cover nested module names like avalon.maya
-    package_name = "{}.{}.lib".format(__name__, host_name)
-    hostlib = importlib.import_module(package_name)
-
-    if not hasattr(hostlib, "get_additional_data"):
-        print("{} has no function called "
-              "get_additional_data".format(package_name))
-        return container
-
-    return hostlib.get_additional_data(container)

--- a/colorbleed/fusion/lib.py
+++ b/colorbleed/fusion/lib.py
@@ -1,5 +1,6 @@
 import sys
 
+from avalon.vendor.Qt import QtGui
 import avalon.fusion
 
 
@@ -58,7 +59,6 @@ def get_additional_data(container):
     if tile_color is None:
         return container
 
-    tile_color.pop("__flags", None)
-    rgb = {key: clamp(value) for key, value in tile_color.items()}
-
-    return {"color": "#{R:02x}{G:02x}{B:02x}".format(**rgb)}
+    return {"color": QtGui.QColor(clamp(tile_color["R"]),
+                                  clamp(tile_color["G"]),
+                                  clamp(tile_color["B"]))}

--- a/colorbleed/fusion/lib.py
+++ b/colorbleed/fusion/lib.py
@@ -38,3 +38,27 @@ def update_frame_range(start, end, comp=None, set_render_range=True):
 
     with avalon.fusion.comp_lock_and_undo_chunk(comp):
         comp.SetAttrs(attrs)
+
+
+def get_additional_data(container):
+    """Get Fusion related data for the container
+
+    Args:
+        container(dict): the container found by the ls() function
+
+    Returns:
+        dict
+    """
+
+    def clamp(value):
+        return int(value * 255)
+
+    tool = container["_tool"]
+    tile_color = tool.TileColor
+    if tile_color is None:
+        return container
+
+    tile_color.pop("__flags", None)
+    rgb = {key: clamp(value) for key, value in tile_color.items()}
+
+    return {"color": "#{R:02x}{G:02x}{B:02x}".format(**rgb)}

--- a/colorbleed/fusion/lib.py
+++ b/colorbleed/fusion/lib.py
@@ -57,7 +57,7 @@ def get_additional_data(container):
     tool = container["_tool"]
     tile_color = tool.TileColor
     if tile_color is None:
-        return container
+        return {}
 
     return {"color": QtGui.QColor(clamp(tile_color["R"]),
                                   clamp(tile_color["G"]),

--- a/colorbleed/fusion/lib.py
+++ b/colorbleed/fusion/lib.py
@@ -51,14 +51,11 @@ def get_additional_data(container):
         dict
     """
 
-    def clamp(value):
-        return int(value * 255)
-
     tool = container["_tool"]
     tile_color = tool.TileColor
     if tile_color is None:
         return {}
 
-    return {"color": QtGui.QColor(clamp(tile_color["R"]),
-                                  clamp(tile_color["G"]),
-                                  clamp(tile_color["B"]))}
+    return {"color": QtGui.QColor.fromRgbF(tile_color["R"],
+                                           tile_color["G"],
+                                           tile_color["B"])}

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -1,6 +1,7 @@
 import os
 import re
 import logging
+import importlib
 
 from .vendor import pather
 from .vendor.pather.error import ParseError
@@ -214,3 +215,37 @@ def switch_item(container,
     avalon.api.switch(container, representation)
 
     return representation
+
+
+def _get_host_name():
+
+    _host = avalon.api.registered_host()
+    # This covers nested module name like avalon.maya
+    return _host.__name__.rsplit(".", 1)[-1]
+
+
+def collect_container_metadata(container):
+    """Add additional data based on the current host
+
+    If the host application's lib module does not have a function to inject
+    additional data it will return the input container
+
+    Args:
+        container (dict): collection if representation data in host
+
+    Returns:
+        generator
+    """
+
+    host_name = _get_host_name()
+
+    # This will cover nested module names like avalon.maya
+    package_name = "{}.{}.lib".format(__name__, host_name)
+    hostlib = importlib.import_module(package_name)
+
+    if not hasattr(hostlib, "get_additional_data"):
+        print("{} has no function called "
+              "get_additional_data".format(package_name))
+        return {}
+
+    return hostlib.get_additional_data(container)

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -209,8 +209,8 @@ def switch_item(container,
                                   "type": "representation",
                                   "parent": version["_id"]})
 
-    assert representation, ("Could not find representation in the database with "
-                            "the name '%s'" % representation_name)
+    assert representation, ("Could not find representation in the database with"
+                            " the name '%s'" % representation_name)
 
     avalon.api.switch(container, representation)
 
@@ -236,7 +236,7 @@ def collect_container_metadata(container):
     Returns:
         generator
     """
-
+    # TODO: Improve method of getting the host lib module
     host_name = _get_host_name()
 
     # This will cover nested module names like avalon.maya

--- a/colorbleed/plugins/fusion/inventory/select_loader_color.py
+++ b/colorbleed/plugins/fusion/inventory/select_loader_color.py
@@ -4,12 +4,13 @@ from avalon.vendor.Qt import QtGui, QtWidgets
 import avalon.fusion
 
 
-class FusionSelectLoaderColor(api.InventoryAction):
+class FusionSetToolColor(api.InventoryAction):
     """Update the color of the selected tools"""
 
-    label = "Select Loader Color"
+    label = "Set Tool Color"
     icon = "plus"
     color = "#d8d8d8"
+    _fallback_color = QtGui.QColor(1.0, 1.0, 1.0)
 
     def process(self, containers):
         """Color all selected tools the selected colors"""
@@ -17,7 +18,8 @@ class FusionSelectLoaderColor(api.InventoryAction):
         comp = avalon.fusion.get_current_comp()
 
         # Launch pick color
-        color = QtGui.QColor(1.0, 1.0, 1.0)
+        first = containers[0]
+        color = QtGui.QColor(first.get("color", self._fallback_color))
         picked_color = QtWidgets.QColorDialog().getColor(color)
         with avalon.fusion.comp_lock_and_undo_chunk(comp):
             for container in containers:

--- a/colorbleed/plugins/fusion/inventory/select_loader_color.py
+++ b/colorbleed/plugins/fusion/inventory/select_loader_color.py
@@ -1,0 +1,35 @@
+from avalon import api
+from avalon.vendor.Qt import QtGui, QtWidgets
+
+import avalon.fusion
+
+
+class FusionSelectLoaderColor(api.InventoryAction):
+
+    label = "Select Loader Color"
+    icon = "plus"
+    color = "#d8d8d8"
+
+    def process(self, containers):
+
+        comp = avalon.fusion.get_current_comp()
+
+        # Get color of selected container
+        _tool = containers[0]["_tool"]
+        table = _tool.TileColor
+        if table:
+            color = QtGui.QColor.fromRgbF(table["R"], table["G"], table["B"])
+        else:
+            color = QtGui.QColor.fromRgbF(0.0, 0.0, 0.0)
+
+        # Launch pick color
+        picked_color = QtWidgets.QColorDialog().getColor(color)
+        with avalon.fusion.comp_lock_and_undo_chunk(comp):
+            for container in containers:
+                # Convert color to 0-1 floats
+                rgb_f = picked_color.getRgbF()
+                rgb_f_table = {"R": rgb_f[0], "G": rgb_f[1], "B": rgb_f[2]}
+
+                # Update tool
+                tool = container["_tool"]
+                tool.TileColor = rgb_f_table

--- a/colorbleed/plugins/fusion/inventory/select_loader_color.py
+++ b/colorbleed/plugins/fusion/inventory/select_loader_color.py
@@ -5,31 +5,36 @@ import avalon.fusion
 
 
 class FusionSelectLoaderColor(api.InventoryAction):
+    """Update the color of the selected tools"""
 
     label = "Select Loader Color"
     icon = "plus"
     color = "#d8d8d8"
 
     def process(self, containers):
+        """Color all selected tools the selected colors"""
 
         comp = avalon.fusion.get_current_comp()
 
-        # Get color of selected container
-        _tool = containers[0]["_tool"]
-        table = _tool.TileColor
-        if table:
-            color = QtGui.QColor.fromRgbF(table["R"], table["G"], table["B"])
-        else:
-            color = QtGui.QColor.fromRgbF(0.0, 0.0, 0.0)
-
         # Launch pick color
+        color = QtGui.QColor(1.0, 1.0, 1.0)
         picked_color = QtWidgets.QColorDialog().getColor(color)
         with avalon.fusion.comp_lock_and_undo_chunk(comp):
             for container in containers:
-                # Convert color to 0-1 floats
+                # Convert color to RGB 0-1 floats
                 rgb_f = picked_color.getRgbF()
                 rgb_f_table = {"R": rgb_f[0], "G": rgb_f[1], "B": rgb_f[2]}
 
                 # Update tool
                 tool = container["_tool"]
                 tool.TileColor = rgb_f_table
+
+        self.refresh()
+
+    def refresh(self):
+        """Refresh Scene Inventory window"""
+
+        app = QtWidgets.QApplication.instance()
+        widgets = dict((w.objectName(), w) for w in app.allWidgets())
+        widget = widgets.get("SceneInventory")
+        widget.refresh()

--- a/colorbleed/plugins/fusion/inventory/select_loader_color.py
+++ b/colorbleed/plugins/fusion/inventory/select_loader_color.py
@@ -15,6 +15,7 @@ class FusionSetToolColor(api.InventoryAction):
     def process(self, containers):
         """Color all selected tools the selected colors"""
 
+        result = []
         comp = avalon.fusion.get_current_comp()
 
         # Launch pick color
@@ -31,12 +32,6 @@ class FusionSetToolColor(api.InventoryAction):
                 tool = container["_tool"]
                 tool.TileColor = rgb_f_table
 
-        self.refresh()
+                result.append(container)
 
-    def refresh(self):
-        """Refresh Scene Inventory window"""
-
-        app = QtWidgets.QApplication.instance()
-        widgets = dict((w.objectName(), w) for w in app.allWidgets())
-        widget = widgets.get("SceneInventory")
-        widget.refresh()
+        return result

--- a/colorbleed/plugins/fusion/inventory/set_tool_color.py
+++ b/colorbleed/plugins/fusion/inventory/set_tool_color.py
@@ -22,6 +22,9 @@ class FusionSetToolColor(api.InventoryAction):
         first = containers[0]
         color = QtGui.QColor(first.get("color", self._fallback_color))
         picked_color = QtWidgets.QColorDialog().getColor(color)
+        if not picked_color.isValid():
+            return result
+
         with avalon.fusion.comp_lock_and_undo_chunk(comp):
             for container in containers:
                 # Convert color to RGB 0-1 floats

--- a/colorbleed/plugins/fusion/inventory/set_tool_color.py
+++ b/colorbleed/plugins/fusion/inventory/set_tool_color.py
@@ -1,4 +1,4 @@
-from avalon import api
+from avalon import api, style
 from avalon.vendor.Qt import QtGui, QtWidgets
 
 import avalon.fusion
@@ -50,12 +50,8 @@ class FusionSetToolColor(api.InventoryAction):
 
         """
 
-        app = QtWidgets.QApplication.instance()
-        widgets = dict((w.objectName(), w) for w in app.allWidgets())
-        widget = widgets.get("SceneInventory")
-
         color_dialog = QtWidgets.QColorDialog(color)
-        color_dialog.setStyleSheet(widget.styleSheet())
+        color_dialog.setStyleSheet(style.load_stylesheet())
 
         accepted = color_dialog.exec_()
         picked_color = color_dialog.selectedColor() if accepted else False

--- a/colorbleed/plugins/fusion/inventory/set_tool_color.py
+++ b/colorbleed/plugins/fusion/inventory/set_tool_color.py
@@ -44,6 +44,10 @@ class FusionSetToolColor(api.InventoryAction):
 
         Args:
             color(QtGui.QColor): Start color to display
+
+        Returns:
+            QtGui.QColor
+
         """
 
         app = QtWidgets.QApplication.instance()

--- a/colorbleed/plugins/fusion/inventory/set_tool_color.py
+++ b/colorbleed/plugins/fusion/inventory/set_tool_color.py
@@ -18,10 +18,18 @@ class FusionSetToolColor(api.InventoryAction):
         result = []
         comp = avalon.fusion.get_current_comp()
 
-        # Launch pick color
+        # Get tool color
         first = containers[0]
-        color = QtGui.QColor(first.get("color", self._fallback_color))
-        picked_color = self.get_color_picker(color)
+        tool = first["_tool"]
+        color = tool.TileColor
+
+        if color is not None:
+            qcolor = QtGui.QColor().fromRgbF(color["R"], color["G"], color["B"])
+        else:
+            qcolor = self._fallback_color
+
+        # Launch pick color
+        picked_color = self.get_color_picker(qcolor)
         if not picked_color:
             return
 

--- a/colorbleed/plugins/fusion/inventory/set_tool_color.py
+++ b/colorbleed/plugins/fusion/inventory/set_tool_color.py
@@ -62,6 +62,7 @@ class FusionSetToolColor(api.InventoryAction):
         color_dialog.setStyleSheet(style.load_stylesheet())
 
         accepted = color_dialog.exec_()
-        picked_color = color_dialog.selectedColor() if accepted else False
+        if not accepted:
+            return
 
-        return picked_color
+        return color_dialog.selectedColor()

--- a/colorbleed/plugins/fusion/inventory/set_tool_color.py
+++ b/colorbleed/plugins/fusion/inventory/set_tool_color.py
@@ -21,9 +21,9 @@ class FusionSetToolColor(api.InventoryAction):
         # Launch pick color
         first = containers[0]
         color = QtGui.QColor(first.get("color", self._fallback_color))
-        picked_color = QtWidgets.QColorDialog().getColor(color)
-        if not picked_color.isValid():
-            return result
+        picked_color = self.get_color_picker(color)
+        if not picked_color:
+            return
 
         with avalon.fusion.comp_lock_and_undo_chunk(comp):
             for container in containers:
@@ -38,3 +38,22 @@ class FusionSetToolColor(api.InventoryAction):
                 result.append(container)
 
         return result
+
+    def get_color_picker(self, color):
+        """Launch color picker and return chosen color
+
+        Args:
+            color(QtGui.QColor): Start color to display
+        """
+
+        app = QtWidgets.QApplication.instance()
+        widgets = dict((w.objectName(), w) for w in app.allWidgets())
+        widget = widgets.get("SceneInventory")
+
+        color_dialog = QtWidgets.QColorDialog(color)
+        color_dialog.setStyleSheet(widget.styleSheet())
+
+        accepted = color_dialog.exec_()
+        picked_color = color_dialog.selectedColor() if accepted else False
+
+        return picked_color


### PR DESCRIPTION
The `collect_container_metadata` functions allows for custom metadata to be collected in each host through the use of the `registered_config` and `registered_host` function of Avalon api.
Each host in the config will have its own `get_additional_data` to ensure it is relevant only for that host.

This merge will introduce the usability of this logic for Fusion and is accompanied with an Inventory plugin.
Please node that this plugin will not work unless [this PR](https://github.com/Colorbleed/core/pull/19) has been resolved together with [this PR](https://github.com/Colorbleed/core/pull/20) for the `SceneInventory`