### PR TITLE
Added set_family_state for cbloader

### DIFF
--- a/colorbleed/fusion/__init__.py
+++ b/colorbleed/fusion/__init__.py
@@ -13,6 +13,8 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "fusion", "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "fusion", "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "fusion", "inventory")
 
+FAMILY_STATES = {"colorbleed.imagesequenbce": True}
+
 
 def install():
     print("Registering Fusion plug-ins..")
@@ -22,6 +24,8 @@ def install():
     avalon.register_plugin_path(avalon.InventoryAction, INVENTORY_PATH)
 
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
+
+    avalon.set_data("family_states", FAMILY_STATES)
 
 
 def uninstall():

--- a/colorbleed/fusion/__init__.py
+++ b/colorbleed/fusion/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-import avalon.io as io
 from avalon import api as avalon
 from pyblish import api as pyblish
 
@@ -25,11 +24,12 @@ def install():
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
     # Disable all families except for the ones we explicitly want to see
-    enabled = {"colorbleed.imagesequence",
-               "colorbleed.camera",
-               "colorbleed.pointcache"}
-    families = set(io.distinct("data.families") + io.distinct("data.family"))
-    avalon.data["familyStates"] = {key: key in enabled for key in families}
+    family_states = ["colorbleed.imagesequence",
+                     "colorbleed.camera",
+                     "colorbleed.pointcache"]
+
+    avalon.data["familiesStateDefault"] = False
+    avalon.data["familiesStateToggled"] = family_states
 
 
 def uninstall():

--- a/colorbleed/fusion/__init__.py
+++ b/colorbleed/fusion/__init__.py
@@ -1,5 +1,6 @@
 import os
 
+import avalon.io as io
 from avalon import api as avalon
 from pyblish import api as pyblish
 
@@ -13,8 +14,6 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "fusion", "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "fusion", "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "fusion", "inventory")
 
-FAMILY_STATES = {"colorbleed.imagesequenbce": True}
-
 
 def install():
     print("Registering Fusion plug-ins..")
@@ -25,7 +24,12 @@ def install():
 
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
-    avalon.set_data("family_states", FAMILY_STATES)
+    # Disable all families except for the ones we explicitly want to see
+    enabled = {"colorbleed.imagesequence",
+               "colorbleed.camera",
+               "colorbleed.pointcache"}
+    families = set(io.distinct("data.families") + io.distinct("data.family"))
+    avalon.data["familyStates"] = {key: key in enabled for key in families}
 
 
 def uninstall():

--- a/colorbleed/fusion/lib.py
+++ b/colorbleed/fusion/lib.py
@@ -38,3 +38,16 @@ def update_frame_range(start, end, comp=None, set_render_range=True):
 
     with avalon.fusion.comp_lock_and_undo_chunk(comp):
         comp.SetAttrs(attrs)
+
+
+def set_family_filter(family_name):
+    """Get state based on what is most related to the host
+
+    Args:
+        family_name (str): name of the family, e.g: "colorbleed.imagesequence"
+
+    Returns:
+        bool
+    """
+
+    return family_name in ["colorbleed.imagesequence"]

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -41,6 +41,11 @@ def install():
     log.info("Overriding existing event 'taskChanged'")
     override_event("taskChanged", on_task_changed)
 
+    log.info("Setting default family states for loader..")
+    avalon.data["familyStates"] = {
+        "colorbleed.imagesequence": False
+    }
+
 
 def uninstall():
     pyblish.deregister_plugin_path(PUBLISH_PATH)

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -42,9 +42,7 @@ def install():
     override_event("taskChanged", on_task_changed)
 
     log.info("Setting default family states for loader..")
-    avalon.data["familyStates"] = {
-        "colorbleed.imagesequence": False
-    }
+    avalon.data["familiesStateToggled"] = ["colorbleed.imagesequence"]
 
 
 def uninstall():


### PR DESCRIPTION
In combination with [this PR](https://github.com/Colorbleed/core/pull/21) adds a family filter based on the config. This is to ensure the right family names are toggled on when the loader is initialized.