### PR TITLE
Fus39b

### DIFF
--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -4,6 +4,7 @@ from pyblish import api as pyblish
 from avalon import api as avalon
 
 from .launcher_actions import register_launcher_actions
+from lib import collect_container_metadata
 
 PACKAGE_DIR = os.path.dirname(__file__)
 PLUGINS_DIR = os.path.join(PACKAGE_DIR, "plugins")

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -238,9 +238,7 @@ def collect_container_metadata(container):
     """
     # TODO: Improve method of getting the host lib module
     host_name = _get_host_name()
-
-    # This will cover nested module names like avalon.maya
-    package_name = "{}.{}.lib".format(__name__, host_name)
+    package_name = "colorbleed.{}.lib".format(host_name)
     hostlib = importlib.import_module(package_name)
 
     if not hasattr(hostlib, "get_additional_data"):


### PR DESCRIPTION
Post fix for [this PR](https://github.com/Colorbleed/colorbleed-config/pull/115)

The address for the host's configuration lib [example: `config.maya.lib` ] was incorrect.
The function `collect_container_metadata` needs to be accessible from the config's init