### PR TITLE
Allow locators in point cache export

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -637,7 +637,8 @@ def get_id_required_nodes(referenced_nodes=False, nodes=None):
         ignore |= set(cmds.ls(type="ilrBakeLayer", long=True))
 
     # Establish set of nodes types to include
-    types = ["objectSet", "file", "mesh", "nurbsCurve", "nurbsSurface"]
+    types = ["objectSet", "file", "mesh", "nurbsCurve", "nurbsSurface",
+             "locator"]
 
     # Check if plugin nodes are available for Maya by checking if the plugin
     # is loaded


### PR DESCRIPTION
The node type `locator` was not in the list of id required nodes because the type needed to be added explicitly. Because of this the node never got an `cbId` and it triggered one or more validators to fail.

Fix: adding the locator type to the types list in the the `get_id_required_nodes`