### PR TITLE
Skipping locator shapes in validator

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -637,8 +637,7 @@ def get_id_required_nodes(referenced_nodes=False, nodes=None):
         ignore |= set(cmds.ls(type="ilrBakeLayer", long=True))
 
     # Establish set of nodes types to include
-    types = ["objectSet", "file", "mesh", "nurbsCurve", "nurbsSurface",
-             "locator"]
+    types = ["objectSet", "file", "mesh", "nurbsCurve", "nurbsSurface"]
 
     # Check if plugin nodes are available for Maya by checking if the plugin
     # is loaded

--- a/colorbleed/plugins/maya/publish/validate_animation_out_set_related_node_ids.py
+++ b/colorbleed/plugins/maya/publish/validate_animation_out_set_related_node_ids.py
@@ -36,6 +36,7 @@ class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin):
         """Get all nodes which do not match the criteria"""
 
         invalid = []
+        types_to_skip = ["locator"]
 
         # get asset id
         nodes = instance.data.get("out_hierarchy", instance[:])
@@ -48,6 +49,10 @@ class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin):
             # Check if node is a shape as deformers only work on shapes
             obj_type = cmds.objectType(node, isAType="shape")
             if not obj_type:
+                continue
+
+            # Skip specific types
+            if cmds.objectType(node) in types_to_skip:
                 continue
 
             # Get the current id of the node


### PR DESCRIPTION
Instead of giving the locators a `cbId` we skip the nodes during `get_invalid` method of `validate_animation_out_set_related_node_ids`.

* Fixes issue PLN 116