### PR TITLE
Implement project FPS

### DIFF
--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -247,3 +247,23 @@ def collect_container_metadata(container):
         return {}
 
     return hostlib.get_additional_data(container)
+
+
+def get_project_fps():
+    """Returns project's FPS, if not found will return 25 by default
+
+    Returns:
+        int, float
+    """
+
+    project_name = io.active_project()
+    project = io.find_one({"name": project_name,
+                           "type": "project"},
+                          projection={"config.fps": True})
+
+    config = project.get("config", None)
+    assert config, "This is a bug"
+
+    fps = config.get("fps", 25)
+
+    return fps

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -259,7 +259,7 @@ def get_project_fps():
     project_name = io.active_project()
     project = io.find_one({"name": project_name,
                            "type": "project"},
-                          projection={"config.fps": True})
+                          projection={"config": True})
 
     config = project.get("config", None)
     assert config, "This is a bug"

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -251,7 +251,7 @@ def get_project_fps():
     """Returns project's FPS, if not found will return 25 by default
 
     Returns:
-        float
+        int, float
     """
 
     project_name = io.active_project()
@@ -264,4 +264,4 @@ def get_project_fps():
 
     fps = config.get("fps", 25.0)
 
-    return float(fps)
+    return fps

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -253,7 +253,7 @@ def get_project_fps():
     """Returns project's FPS, if not found will return 25 by default
 
     Returns:
-        int, float
+        float
     """
 
     project_name = io.active_project()
@@ -264,6 +264,6 @@ def get_project_fps():
     config = project.get("config", None)
     assert config, "This is a bug"
 
-    fps = config.get("fps", 25)
+    fps = config.get("fps", 25.0)
 
-    return fps
+    return float(fps)

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -122,7 +122,7 @@ def on_open(_):
     from ..widgets import popup
 
     # Ensure scene's FPS is set to project config
-    lib.set_project_fps()
+    lib.validate_fps()
 
     # Update current task for the current scene
     update_task_from_path(cmds.file(query=True, sceneName=True))
@@ -174,5 +174,3 @@ def on_task_changed(*args):
 
     # Run
     maya.pipeline._on_task_changed()
-
-

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -126,15 +126,17 @@ def on_save(_):
                              QtWidgets.QApplication.topLevelWidgets()}
 
         parent = top_level_widgets.get("MayaWindow", None)
+        if parent is None:
+            pass
+        else:
+            dialog = popup.Popup(parent=parent)
+            dialog.setWindowTitle("Maya scene not in line with project")
+            dialog.setMessage("The FPS is out of sync, please fix")
+            # Set new text for button (add optional argument for the popup?)
+            dialog.widgets["show"].setText("Fix")
+            dialog.on_show.connect(lib.set_project_fps)
 
-        dialog = popup.Popup(parent=parent)
-        dialog.setWindowTitle("Maya scene not in line with project")
-        dialog.setMessage("The FPS is out of sync, please fix")
-        # Set new text for button (could be an optional argument for the popup)
-        dialog.widgets["show"].setText("Fix")
-        dialog.on_show.connect(lib.set_project_fps)
-
-        dialog.show()
+            dialog.show()
 
 
 def on_open(_):

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -2,7 +2,7 @@ import os
 import logging
 import weakref
 
-from maya import utils, cmds, mel, OpenMaya as om
+from maya import utils, cmds, mel
 
 from avalon import api as avalon, pipeline, maya
 from pyblish import api as pyblish

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -10,7 +10,6 @@ from pyblish import api as pyblish
 from ..lib import (
     update_task_from_path,
     any_outdated,
-    get_project_fps
 )
 from . import menu
 from . import lib
@@ -94,13 +93,13 @@ def on_init(_):
 
     from .customize import override_component_mask_commands
     safe_deferred(override_component_mask_commands)
-    safe_deferred(lib.set_project_fps)
 
 
 def on_save(_):
     """Automatically add IDs to new nodes
-    Any transform of a mesh, without an existing ID,
-    is given one automatically on file save.
+
+    Any transform of a mesh, without an existing ID, is given one
+    automatically on file save.
     """
 
     avalon.logger.info("Running callback on save..")
@@ -113,30 +112,7 @@ def on_save(_):
     for node, new_id in lib.generate_ids(nodes):
         lib.set_id(node, new_id, overwrite=False)
 
-    # Valid FPS
-    current_fps = mel.eval('currentTimeUnitToFPS()')  # returns float
-    fps = get_project_fps()
-    if fps != current_fps:
-
-        from avalon.vendor.Qt import QtWidgets
-        from ..widgets import popup
-
-        # Find maya main window
-        top_level_widgets = {w.objectName(): w for w in
-                             QtWidgets.QApplication.topLevelWidgets()}
-
-        parent = top_level_widgets.get("MayaWindow", None)
-        if parent is None:
-            pass
-        else:
-            dialog = popup.Popup(parent=parent)
-            dialog.setWindowTitle("Maya scene not in line with project")
-            dialog.setMessage("The FPS is out of sync, please fix")
-            # Set new text for button (add optional argument for the popup?)
-            dialog.widgets["show"].setText("Fix")
-            dialog.on_show.connect(lib.set_project_fps)
-
-            dialog.show()
+    lib.validate_fps()
 
 
 def on_open(_):
@@ -198,3 +174,5 @@ def on_task_changed(*args):
 
     # Run
     maya.pipeline._on_task_changed()
+
+

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -2,8 +2,7 @@ import os
 import logging
 import weakref
 
-from maya import utils
-from maya import cmds
+from maya import utils, cmds
 
 from avalon import api as avalon, pipeline, maya
 from pyblish import api as pyblish
@@ -94,6 +93,7 @@ def on_init(_):
 
     from .customize import override_component_mask_commands
     safe_deferred(override_component_mask_commands)
+    safe_deferred(lib.set_project_fps)
 
 
 def on_save(_):
@@ -118,6 +118,9 @@ def on_open(_):
 
     from avalon.vendor.Qt import QtWidgets
     from ..widgets import popup
+
+    # Ensure scene's FPS is set to project config
+    lib.set_project_fps()
 
     # Update current task for the current scene
     update_task_from_path(cmds.file(query=True, sceneName=True))

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -9,7 +9,7 @@ from pyblish import api as pyblish
 
 from ..lib import (
     update_task_from_path,
-    any_outdated,
+    any_outdated
 )
 from . import menu
 from . import lib
@@ -37,7 +37,7 @@ def install():
     avalon.on("save", on_save)
     avalon.on("open", on_open)
 
-    avalon.before("save", before_save_check)
+    avalon.before("save", on_before_save)
 
     log.info("Overriding existing event 'taskChanged'")
     override_event("taskChanged", on_task_changed)
@@ -97,7 +97,7 @@ def on_init(_):
     safe_deferred(override_component_mask_commands)
 
 
-def before_save_check(return_code, _):
+def on_before_save(return_code, _):
     """Run validation for scene's FPS prior to saving"""
     return lib.validate_fps()
 

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1322,27 +1322,22 @@ def set_project_fps():
 
     """
 
-    int_fps = [15, 24, 5, 30, 48, 50, 60, 44100, 48000]
-    float_fps = [23.976, 29.97, 29.97, 47.952, 59.94]
+    int_fps = {15, 24, 5, 30, 48, 50, 60, 44100, 48000}
+    float_fps = {23.976, 29.97, 29.97, 47.952, 59.94}
 
     fps = lib.get_project_fps()
 
-    if not isinstance(fps, (int, float)):
-        raise ValueError("Set value for project's FPS is not a number. "
-                         "Only accepts floats and integers")
+    if isinstance(fps, float) and fps in float_fps:
+        unit = "{:f}fps".format(int(fps))
 
-    if int(fps) in int_fps:
-        update_str = "{:d}fps".format(int(fps))
-
-    elif fps in float_fps:
-        update_str = "{:f}fps".format(fps)
+    elif int(fps) in int_fps:
+        unit = "{:d}fps".format(int(fps))
 
     else:
-        raise RuntimeError("Unsupported FPS value: `%s`" % fps)
+        raise ("Unsupported FPS value: `%s`" % fps)
 
-    log.info("Updating FPS to '{}'".format(update_str))
-
-    cmds.currentUnit(time=update_str)
+    log.info("Updating FPS to '{}'".format(unit))
+    cmds.currentUnit(time=unit)
 
 
 # Valid FPS

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -13,7 +13,7 @@ from collections import OrderedDict, defaultdict
 from maya import cmds, mel
 
 from avalon import api, maya, io, pipeline
-from cb.utils.maya import core
+from colorbleed import lib
 import cb.utils.maya.context
 
 
@@ -1292,3 +1292,21 @@ def get_id_from_history(node):
         _id = get_id(similar_node)
         if _id:
             return _id
+
+
+def set_project_fps():
+    """Set FPS from project configuration"""
+
+    fps = lib.get_project_fps()
+    if not isinstance(fps, (int, float)):
+        raise ValueError("Set value for project's FPS is not a number. "
+                         "Only accepts floats and integers")
+
+    if int(fps) == 24:
+        cmds.currentUnit(time="film")
+        log.info("Updated FPS to 24 (film)")
+    elif int(fps) == 25:
+        cmds.currentUnit(time="pal")
+        log.info("Updated FPS to 25 (pal)")
+    else:
+        raise RuntimeError("Cannot translate FPS: `%s`" % fps)

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1356,17 +1356,7 @@ def validate_fps():
     fps = lib.get_project_fps()  # can be int or float
     current_fps = mel.eval('currentTimeUnitToFPS()')  # returns float
 
-    # Check if FPS is supported in Maya and compare with current fps
-    if isinstance(fps, int) and fps in INT_FPS:
-        valid = int(current_fps) == fps
-
-    elif isinstance(fps, float) and fps in FLOAT_FPS:
-        valid = current_fps == fps
-
-    else:
-        valid = False
-
-    if not valid:
+    if current_fps != fps:
 
         from avalon.vendor.Qt import QtWidgets
         from ..widgets import popup

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1305,8 +1305,10 @@ def set_project_fps():
     if int(fps) == 24:
         cmds.currentUnit(time="film")
         log.info("Updated FPS to 24 (film)")
+
     elif int(fps) == 25:
         cmds.currentUnit(time="pal")
         log.info("Updated FPS to 25 (pal)")
+
     else:
         raise RuntimeError("Cannot translate FPS: `%s`" % fps)

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -16,7 +16,6 @@ from avalon import api, maya, io, pipeline
 from colorbleed import lib
 
 
-
 log = logging.getLogger(__name__)
 
 ATTRIBUTE_DICT = {"int": {"attributeType": "long"},
@@ -1339,13 +1338,16 @@ def set_project_fps():
     log.info("Updating FPS to '{}'".format(unit))
     cmds.currentUnit(time=unit)
 
+    # Force file stated to 'modified'
+    cmds.file(modified=True)
+
 
 # Valid FPS
 def validate_fps():
     """Validate current scene FPS and show pop-up when it is incorrect
 
     Returns:
-        None
+        bool
 
     """
 
@@ -1365,10 +1367,16 @@ def validate_fps():
             pass
         else:
             dialog = popup.Popup(parent=parent)
+            dialog.setModal(True)
             dialog.setWindowTitle("Maya scene not in line with project")
             dialog.setMessage("The FPS is out of sync, please fix")
+
             # Set new text for button (add optional argument for the popup?)
             dialog.widgets["show"].setText("Fix")
             dialog.on_show.connect(set_project_fps)
 
             dialog.show()
+
+            return False
+
+    return True

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1313,8 +1313,11 @@ def get_id_from_history(node):
             return _id
 
 
-def set_project_fps():
+def set_project_fps(update=True):
     """Set FPS from project configuration
+
+    Args:
+        update(bool): toggle update animation, default is True
 
     Returns:
         None
@@ -1336,7 +1339,7 @@ def set_project_fps():
         raise ("Unsupported FPS value: `%s`" % fps)
 
     log.info("Updating FPS to '{}'".format(unit))
-    cmds.currentUnit(time=unit)
+    cmds.currentUnit(time=unit, updateAnimation=update)
 
     # Force file stated to 'modified'
     cmds.file(modified=True)
@@ -1366,14 +1369,15 @@ def validate_fps():
         if parent is None:
             pass
         else:
-            dialog = popup.Popup(parent=parent)
+            dialog = popup.Popup2(parent=parent)
             dialog.setModal(True)
             dialog.setWindowTitle("Maya scene not in line with project")
             dialog.setMessage("The FPS is out of sync, please fix")
 
             # Set new text for button (add optional argument for the popup?)
-            dialog.widgets["show"].setText("Fix")
-            dialog.on_show.connect(set_project_fps)
+            toggle = dialog.widgets["toggle"]
+            update = toggle.isChecked()
+            dialog.on_show.connect(lambda: set_project_fps(update))
 
             dialog.show()
 

--- a/colorbleed/plugins/maya/publish/validate_maya_units.py
+++ b/colorbleed/plugins/maya/publish/validate_maya_units.py
@@ -2,6 +2,8 @@ import maya.cmds as cmds
 
 import pyblish.api
 import colorbleed.api
+from colorbleed import lib
+import colorbleed.maya.lib as mayalib
 
 
 class ValidateMayaUnits(pyblish.api.ContextPlugin):
@@ -16,19 +18,21 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
 
         linearunits = context.data('linearUnits')
         angularunits = context.data('angularUnits')
+
         fps = context.data['fps']
+        project_fps = lib.get_project_fps()
 
         self.log.info('Units (linear): {0}'.format(linearunits))
         self.log.info('Units (angular): {0}'.format(angularunits))
         self.log.info('Units (time): {0} FPS'.format(fps))
 
-        # check if units are correct
+        # Check if units are correct
         assert linearunits and linearunits == 'cm', ("Scene linear units must "
                                                      "be centimeters")
 
         assert angularunits and angularunits == 'deg', ("Scene angular units "
                                                         "must be degrees")
-        assert fps and fps == 25.0, "Scene must be 25 FPS"
+        assert fps and fps == project_fps, "Scene must be %s FPS" % project_fps
 
     @classmethod
     def repair(cls):
@@ -44,7 +48,5 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         current_linear = cmds.currentUnit(query=True, linear=True)
         cls.log.debug(current_linear)
 
-        cls.log.info("Setting time unit to 'PAL'")
-        cmds.currentUnit(time="pal")
-        current_time = cmds.currentUnit(query=True, time=True)
-        cls.log.debug(current_time)
+        cls.log.info("Setting time unit to match project")
+        mayalib.set_project_fps()

--- a/colorbleed/plugins/maya/publish/validate_maya_units.py
+++ b/colorbleed/plugins/maya/publish/validate_maya_units.py
@@ -49,4 +49,5 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         cls.log.debug(current_linear)
 
         cls.log.info("Setting time unit to match project")
-        mayalib.set_project_fps()
+        project_fps = lib.get_project_fps()
+        mayalib.set_scene_fps(project_fps)

--- a/colorbleed/widgets/popup.py
+++ b/colorbleed/widgets/popup.py
@@ -104,105 +104,25 @@ class Popup(QtWidgets.QDialog):
         return QtCore.QRect(x, y, width, height)
 
 
-class Popup2(QtWidgets.QDialog):
+class Popup2(Popup):
 
     on_show = QtCore.Signal()
 
     def __init__(self, parent=None, *args, **kwargs):
-        QtWidgets.QDialog.__init__(self, parent=parent, *args, **kwargs)
-        self.setContentsMargins(0, 0, 0, 0)
+        Popup.__init__(self, parent=parent, *args, **kwargs)
 
-        # Layout
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(10, 5, 10, 10)
-        message = QtWidgets.QLabel("")
-        message.setStyleSheet("""
-        QLabel {
-            font-size: 12px;
-        }
-        """)
-        show = QtWidgets.QPushButton("Fix")
-        show.setSizePolicy(QtWidgets.QSizePolicy.Maximum,
-                           QtWidgets.QSizePolicy.Maximum)
-        show.setStyleSheet("""QPushButton { background-color: #BB0000 }""")
+        layout = self.layout()
 
-        toggle = QtWidgets.QCheckBox()
-        toggle.setText("Update Keys")
+        # Add toggle
+        toggle = QtWidgets.QCheckBox("Update Keys")
+        layout.insertWidget(1, toggle)
+        self.widgets["toggle"] = toggle
 
-        layout.addWidget(message, 1)  # Ensure stretch
-        layout.addWidget(toggle)
-        layout.addWidget(show)
+        layout.insertStretch(1, 1)
 
-        # Size
-        self.resize(400, 40)
-        geometry = self.calculate_window_geometry()
-        self.setGeometry(geometry)
-
-        self.widgets = {
-            "message": message,
-            "show": show,
-            "toggle": toggle,
-        }
-
-        # Signals
-        show.clicked.connect(self._on_show_clicked)
-
-        # Set default title
-        self.setWindowTitle("Popup")
-
-    def setMessage(self, message):
-        self.widgets['message'].setText(message)
-
-    def _on_show_clicked(self):
-        """Callback for when the 'show' button is clicked.
-
-        Raises the parent (if any)
-
-        """
-
-        parent = self.parent()
-        self.close()
-
-        # Trigger the signal
-        self.on_show.emit()
-
-        if parent:
-            parent.raise_()
-
-    def calculate_window_geometry(self):
-        """Respond to status changes
-
-        On creation, align window with screen bottom right.
-
-        """
-
-        window = self
-
-        width = window.width()
-        width = max(width, window.minimumWidth())
-
-        height = window.height()
-        height = max(height, window.sizeHint().height())
-
-        desktop_geometry = QtWidgets.QDesktopWidget().availableGeometry()
-        screen_geometry = window.geometry()
-
-        screen_width = screen_geometry.width()
-        screen_height = screen_geometry.height()
-
-        # Calculate width and height of system tray
-        systray_width = screen_geometry.width() - desktop_geometry.width()
-        systray_height = screen_geometry.height() - desktop_geometry.height()
-
-        padding = 10
-
-        x = screen_width - width
-        y = screen_height - height
-
-        x -= systray_width + padding
-        y -= systray_height + padding
-
-        return QtCore.QRect(x, y, width, height)
+        # Update button text
+        fix = self.widgets["show"]
+        fix.setText("Fix")
 
 
 @contextlib.contextmanager

--- a/colorbleed/widgets/popup.py
+++ b/colorbleed/widgets/popup.py
@@ -104,6 +104,107 @@ class Popup(QtWidgets.QDialog):
         return QtCore.QRect(x, y, width, height)
 
 
+class Popup2(QtWidgets.QDialog):
+
+    on_show = QtCore.Signal()
+
+    def __init__(self, parent=None, *args, **kwargs):
+        QtWidgets.QDialog.__init__(self, parent=parent, *args, **kwargs)
+        self.setContentsMargins(0, 0, 0, 0)
+
+        # Layout
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(10, 5, 10, 10)
+        message = QtWidgets.QLabel("")
+        message.setStyleSheet("""
+        QLabel {
+            font-size: 12px;
+        }
+        """)
+        show = QtWidgets.QPushButton("Fix")
+        show.setSizePolicy(QtWidgets.QSizePolicy.Maximum,
+                           QtWidgets.QSizePolicy.Maximum)
+        show.setStyleSheet("""QPushButton { background-color: #BB0000 }""")
+
+        toggle = QtWidgets.QCheckBox()
+        toggle.setText("Update Keys")
+
+        layout.addWidget(message, 1)  # Ensure stretch
+        layout.addWidget(toggle)
+        layout.addWidget(show)
+
+        # Size
+        self.resize(400, 40)
+        geometry = self.calculate_window_geometry()
+        self.setGeometry(geometry)
+
+        self.widgets = {
+            "message": message,
+            "show": show,
+            "toggle": toggle,
+        }
+
+        # Signals
+        show.clicked.connect(self._on_show_clicked)
+
+        # Set default title
+        self.setWindowTitle("Popup")
+
+    def setMessage(self, message):
+        self.widgets['message'].setText(message)
+
+    def _on_show_clicked(self):
+        """Callback for when the 'show' button is clicked.
+
+        Raises the parent (if any)
+
+        """
+
+        parent = self.parent()
+        self.close()
+
+        # Trigger the signal
+        self.on_show.emit()
+
+        if parent:
+            parent.raise_()
+
+    def calculate_window_geometry(self):
+        """Respond to status changes
+
+        On creation, align window with screen bottom right.
+
+        """
+
+        window = self
+
+        width = window.width()
+        width = max(width, window.minimumWidth())
+
+        height = window.height()
+        height = max(height, window.sizeHint().height())
+
+        desktop_geometry = QtWidgets.QDesktopWidget().availableGeometry()
+        screen_geometry = window.geometry()
+
+        screen_width = screen_geometry.width()
+        screen_height = screen_geometry.height()
+
+        # Calculate width and height of system tray
+        systray_width = screen_geometry.width() - desktop_geometry.width()
+        systray_height = screen_geometry.height() - desktop_geometry.height()
+
+        padding = 10
+
+        x = screen_width - width
+        y = screen_height - height
+
+        x -= systray_width + padding
+        y -= systray_height + padding
+
+        return QtCore.QRect(x, y, width, height)
+
+
 @contextlib.contextmanager
 def application():
     app = QtWidgets.QApplication(sys.argv)


### PR DESCRIPTION
To improve the flexibility of the projects we added a `get_project_fps` function to check if the host application has the same fps as the project.

In `colorbleed.lib`:
* Get project FPS

In `colorbleed.maya.__init__` and `colorbleed.maya.lib`
* Setting FPS to match project add launch (not all types are covert yet!)
* Setting FPS to match project when opening a file
* Validate on save if FPS matches project

Pyblish Maya plugins:
* Updated validator for Maya Units to check current FPS against project config