### PR TITLE
Fixed bug in attribute_values

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -13,6 +13,7 @@ from collections import OrderedDict, defaultdict
 from maya import cmds, mel
 
 from avalon import api, maya, io, pipeline
+from avalon.vendor.six import string_types
 
 
 log = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ def matrix_equals(a, b, tolerance=1e-10):
 
 
 def unique(name):
-    assert isinstance(name, basestring), "`name` must be string"
+    assert isinstance(name, string_types), "`name` must be string"
 
     while cmds.objExists(name):
         matches = re.findall(r"\d+$", name)
@@ -270,6 +271,31 @@ def collect_animation_data():
     data["step"] = 1.0
 
     return data
+
+
+@contextlib.contextmanager
+def attribute_values(attr_values):
+    """Remaps node attributes to values during context.
+
+    Arguments:
+        attr_values (dict): Dictionary with (attr, value)
+
+    """
+
+    original = [(attr, cmds.getAttr(attr)) for attr in attr_values]
+    try:
+        for attr, value in attr_values.items():
+            if isinstance(value, string_types):
+                cmds.setAttr(attr, value, type="string")
+            else:
+                cmds.setAttr(attr, value)
+        yield
+    finally:
+        for attr, value in original:
+            if isinstance(value, string_types):
+                cmds.setAttr(attr, value, type="string")
+            else:
+                cmds.setAttr(attr, value)
 
 
 @contextlib.contextmanager

--- a/colorbleed/plugins/maya/publish/extract_look.py
+++ b/colorbleed/plugins/maya/publish/extract_look.py
@@ -7,6 +7,7 @@ from maya import cmds
 import pyblish.api
 import avalon.maya
 import colorbleed.api
+import colorbleed.maya.lib as maya
 
 from cb.utils.maya import context
 
@@ -65,7 +66,7 @@ class ExtractLook(colorbleed.api.Extractor):
         with context.renderlayer(layer):
             # TODO: Ensure membership edits don't become renderlayer overrides
             with context.empty_sets(sets, force=True):
-                with context.attribute_values(remap):
+                with maya.attribute_values(remap):
                     with avalon.maya.maintained_selection():
                         cmds.select(sets, noExpand=True)
                         cmds.file(maya_path,

--- a/colorbleed/plugins/maya/publish/extract_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/extract_yeti_rig.py
@@ -6,7 +6,7 @@ from maya import cmds
 
 import avalon.maya.lib as lib
 import colorbleed.api
-from cb.utils.maya import context
+import colorbleed.maya.lib as maya
 
 
 @contextlib.contextmanager
@@ -25,7 +25,7 @@ def disconnected_attributes(settings, members):
             try:
                 source = sources[0]
             except IndexError:
-                print "source_id:", input["sourceID"]
+                print("source_id:", input["sourceID"])
                 continue
 
             # Get destination shapes (the shapes used as hook up)
@@ -52,7 +52,7 @@ def disconnected_attributes(settings, members):
             try:
                 cmds.connectAttr(connection[0], connection[1])
             except Exception as e:
-                print e,
+                print(e)
                 continue
 
 
@@ -112,7 +112,7 @@ class ExtractYetiRig(colorbleed.api.Extractor):
 
         nodes = instance.data["setMembers"]
         with disconnected_attributes(settings, members):
-            with context.attribute_values(attr_value):
+            with maya.attribute_values(attr_value):
                 cmds.select(nodes, noExpand=True)
                 cmds.file(maya_path,
                           force=True,


### PR DESCRIPTION
The contextmanager function `attribute_values` had conflicting results when it came to resolving string type values. To resolve the issue I moved the function to `colorbleed.maya.lib` to be able to use `six.string_type`.

_Changes:_
* Added function to `colorbleed.maya.lib`
* Updated module who used that function