### PR TITLE
Add pools to deadline submission

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_renderglobals.py
+++ b/colorbleed/plugins/maya/create/colorbleed_renderglobals.py
@@ -30,6 +30,7 @@ class CreateRenderGlobals(avalon.maya.Creator):
         data["priority"] = 50
         data["whitelist"] = False
         data["machineList"] = ""
+        data["pools"] = ""
 
         self.data = data
         self.options = {"useSelection": False}  # Force no content

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -122,6 +122,15 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
 
         options = {"renderGlobals": {}}
         options["renderGlobals"]["Priority"] = attributes["priority"]
+
+        # Check for specific pools
+        pool_str = attributes.get("pools", None)
+        if pool_str is not None and not "":
+            pools = pool_str.split(";")
+            options["renderGlobals"]["Pool"] = pools[0]
+            if len(pools) > 1:
+                options["renderGlobals"]["SecondaryPool"] = pools[1]
+
         legacy = attributes["useLegacyRenderLayers"]
         options["renderGlobals"]["UseLegacyRenderLayers"] = legacy
 

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -125,7 +125,7 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
 
         # Check for specific pools
         pool_str = attributes.get("pools", None)
-        if pool_str is not None and not "":
+        if pool_str:
             pools = pool_str.split(";")
             options["renderGlobals"]["Pool"] = pools[0]
             if len(pools) > 1:


### PR DESCRIPTION
Added support for pools, this allows the artist to set a specific pool of computer to be assigned to the job(s)

* Updated renderglobals instance
* Updated `collect_renderlayer`

Merge this [PR](https://github.com/Colorbleed/colorbleed-config/pull/132) to open support in UI