### PR TITLE
Explicit check for secondary pool

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -126,10 +126,10 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
         # Check for specific pools
         pool_str = attributes.get("pools", None)
         if pool_str:
-            pools = pool_str.split(";")
-            options["renderGlobals"]["Pool"] = pools[0]
-            if len(pools) > 1:
-                options["renderGlobals"]["SecondaryPool"] = pools[1]
+            pool_a, pool_b = pool_str.split(";")
+            options["renderGlobals"].update({"Pool": pool_a})
+            if pool_b and pool_b != "-":
+                options["renderGlobals"].update({"SecondaryPool": pool_a})
 
         legacy = attributes["useLegacyRenderLayers"]
         options["renderGlobals"]["UseLegacyRenderLayers"] = legacy


### PR DESCRIPTION
Ensure `Secondary Pool` is only passed on if it is valid. The new entry: `-` will block the secondary pool assignment. This is to counter Deadline's default pool assignment which is `none`.