### PR TITLE
Fixed updating Yeti cache

### DIFF
--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -271,8 +271,8 @@ class YetiCacheLoader(api.Loader):
                 lib.set_attribute(attr, value, yeti_node)
 
             # Fix for : YETI-6
-            # Fixes the render stats
-            # (see Perigrene's ../scripts/pgYetiNode.mel script)
+            # Fixes the render stats (this is literally taken from Perigrene's
+            # ../scripts/pgYetiNode.mel script)
             cmds.setAttr("{}.visibleInReflections".format(yeti_node), True)
             cmds.setAttr("{}.visibleInRefractions".format(yeti_node), True)
 

--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -7,6 +7,7 @@ from maya import cmds
 
 from avalon import api
 from avalon.maya import lib as avalon_lib, pipeline
+from avalon.vendor import six
 from colorbleed.maya import lib
 
 
@@ -176,14 +177,19 @@ class YetiCacheLoader(api.Loader):
             nodes.append(transform_node)
             nodes.append(yeti_node)
 
+            # Update visibility reflaction and refraction in node settings
+            attributes = node_settings["attrs"]
+            attributes.update({"visibleInReflections": True,
+                               "visibleInRefractions": True})
+
             # Apply attributes to pgYetiMaya node
             kwargs = {}
-            for attr, value in node_settings["attrs"].items():
+            for attr, value in attributes.items():
                 if value is None:
                     continue
 
                 attribute = "%s.%s" % (yeti_node, attr)
-                if isinstance(value, (str, unicode)):
+                if isinstance(value, (str, six.string_types)):
                     cmds.setAttr(attribute, value, type="string")
                     continue
 


### PR DESCRIPTION
Extended the update logic for the Yeti Cache loader. It was not properly adding or removing the nodes of the container(s).

It is based on the content of the container and the metadata which is published along with the cache. Both the container and the metadata are used to create a lookup with `defaultdict` based on `cbId`. This way we support renaming and adjusting the correct nodes. All IDs which are not in the metadata look up are to be deleted, all new IDs in the metadata file are created and added to the container.