### PR TITLE
Introduce VRay proxy

### DIFF
--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -24,3 +24,9 @@ def uninstall():
     print("Deregistering global plug-ins..")
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     avalon.deregister_plugin_path(avalon.Loader, LOAD_PATH)
+
+
+def register_loader_plugins():
+    """Wrap to install Loader plugins for standalone"""
+
+    install()

--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -24,9 +24,3 @@ def uninstall():
     print("Deregistering global plug-ins..")
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     avalon.deregister_plugin_path(avalon.Loader, LOAD_PATH)
-
-
-def register_loader_plugins():
-    """Wrap to install Loader plugins for standalone"""
-
-    install()

--- a/colorbleed/plugins/global/load/copy_file.py
+++ b/colorbleed/plugins/global/load/copy_file.py
@@ -1,0 +1,35 @@
+from avalon import api, style
+
+
+class CopyFile(api.Loader):
+    """Copy the published file to be pasted at the desired location"""
+
+    representations = ["*"]
+    families = ["*"]
+
+    label = "Copy File"
+    order = 10
+    icon = "copy"
+    color = style.colors.default
+
+    def load(self, context, name=None, namespace=None, data=None):
+        self.log.info("Added copy to clipboard: {0}".format(self.fname))
+        self.copy_file_to_clipboard(self.fname)
+
+    @staticmethod
+    def copy_file_to_clipboard(path):
+        from avalon.vendor.Qt import QtCore, QtWidgets
+
+        app = QtWidgets.QApplication.instance()
+        assert app, "Must have running QApplication instance"
+
+        # Build mime data for clipboard
+        file_path = QtCore.QUrl.fromLocalFile(path)
+        byte_array = QtCore.QByteArray("copy\n").append(file_path)
+
+        mime = QtCore.QMimeData()
+        mime.setData("text/uri-list", byte_array)
+
+        # Set to Clipboard
+        clipboard = app.clipboard()
+        clipboard.setMimeData(mime)

--- a/colorbleed/plugins/global/load/copy_to_clipboard.py
+++ b/colorbleed/plugins/global/load/copy_to_clipboard.py
@@ -6,13 +6,13 @@ class CopyToClipboardLoader(api.Loader):
     representations = ["*"]
     families = ["*"]
 
-    label = "Copy to Clipboard"
+    label = "Copy file path to Clipboard"
     order = 20
     icon = "clipboard"
     color = "#999999"
 
     def load(self, context, name=None, namespace=None, data=None):
-        self.log.info("Added to clipboard: {0}".format(self.fname))
+        self.log.info("Added file path to clipboard: {0}".format(self.fname))
         self.copy_file_to_clipboard(self.fname)
 
     @staticmethod

--- a/colorbleed/plugins/global/publish/integrate.py
+++ b/colorbleed/plugins/global/publish/integrate.py
@@ -32,6 +32,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "colorbleed.pointcache",
                 "colorbleed.setdress",
                 "colorbleed.rig",
+                "colorbleed.vrayproxy",
                 "colorbleed.yetiRig",
                 "colorbleed.yeticache"]
 
@@ -191,7 +192,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 # |_______|
                 #
                 fname = files
-                assert not os.path.isabs(fname)
+                assert not os.path.isabs(fname), (
+                    "Given file name is a full path"
+                )
                 _, ext = os.path.splitext(fname)
 
                 template_data["representation"] = ext[1:]

--- a/colorbleed/plugins/maya/create/colorbleed_vrayproxy.py
+++ b/colorbleed/plugins/maya/create/colorbleed_vrayproxy.py
@@ -1,0 +1,10 @@
+import avalon.maya
+
+
+class CreatePointCache(avalon.maya.Creator):
+    """Alembic pointcache for animated data"""
+
+    name = "vrayproxy"
+    label = "VRay Proxy"
+    family = "colorbleed.vrayproxy"
+    icon = "gears"

--- a/colorbleed/plugins/maya/create/colorbleed_vrayproxy.py
+++ b/colorbleed/plugins/maya/create/colorbleed_vrayproxy.py
@@ -1,10 +1,23 @@
+from collections import OrderedDict
+
 import avalon.maya
 
 
-class CreatePointCache(avalon.maya.Creator):
+class CreateVrayProxy(avalon.maya.Creator):
     """Alembic pointcache for animated data"""
 
     name = "vrayproxy"
     label = "VRay Proxy"
     family = "colorbleed.vrayproxy"
     icon = "gears"
+
+    def __init__(self, *args, **kwargs):
+        super(CreateVrayProxy, self).__init__(*args, **kwargs)
+
+        data = OrderedDict(**self.data)
+
+        data["animation"] = False
+        data["startFrame"] = 1
+        data["endFrame"] = 1
+
+        self.data.update(data)

--- a/colorbleed/plugins/maya/load/load_vrayproxy.py
+++ b/colorbleed/plugins/maya/load/load_vrayproxy.py
@@ -1,0 +1,98 @@
+from avalon.maya import lib
+import colorbleed.maya.plugin
+
+import maya.cmds as cmds
+
+
+class VRayProxyLoader(colorbleed.maya.plugin.ReferenceLoader):
+    """Load vrmesh files"""
+
+    families = ["colorbleed.vrayproxy"]
+    representations = ["vrmesh"]
+
+    label = "Reference VRay Proxy"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    def process_reference(self, context, name, namespace, data):
+
+        asset_name = context['asset']["name"]
+        print("---", namespace)
+
+        namespace = namespace or lib.unique_namespace(
+            asset_name + "_",
+            prefix="_" if asset_name[0].isdigit() else "",
+            suffix="_",
+        )
+
+        print(">>>", namespace)
+
+        # Pre-run check
+        if not cmds.objExists("vraySettings"):
+            cmds.createNode("VRaySettingsNode", name="vraySettings")
+
+        # Add namespace
+        cmds.namespace(set=":")
+        cmds.namespace(add=namespace)
+        cmds.namespace(set=namespace)
+
+        with lib.maintained_selection():
+            nodes = self.create_vray_proxy(name)
+
+        self[:] = nodes
+
+        return nodes
+
+    def create_vray_proxy(self, name, attrs=None):
+        """Re-create the structure created by VRay to support vrmeshes
+
+        Args:
+            name(str): name of the asset
+
+        Returns:
+            nodes(list)
+        """
+
+        # Create nodes
+        vray_mesh = cmds.createNode('VRayMesh', name="{}_VRMS".format(name))
+        mesh_shape = cmds.createNode("mesh", name="{}_GEOShape".format(name))
+        vray_mat = cmds.createNode("VRayMeshMaterial",
+                                   name="{}_VRMM".format(name))
+        vray_mat_sg = cmds.createNode("shadingEngine",
+                                      name="{}_VRSG".format(name))
+
+        cmds.setAttr("{}.fileName2".format(vray_mesh),
+                     self.fname,
+                     type="string")
+
+        # Apply attributes from export
+        # cmds.setAttr("{}.animType".format(vray_mesh), 3)
+
+        # Create important connections
+        cmds.connectAttr("{}.fileName2".format(vray_mesh),
+                         "{}.fileName".format(vray_mat))
+        cmds.connectAttr("{}.instancing".format(vray_mesh),
+                         "{}.instancing".format(vray_mat))
+        cmds.connectAttr("{}.output".format(vray_mesh),
+                         "{}.inMesh".format(mesh_shape))
+        cmds.connectAttr("{}.overrideFileName".format(vray_mesh),
+                         "{}.overrideFileName".format(vray_mat))
+        cmds.connectAttr("{}.currentFrame".format(vray_mesh),
+                         "{}.currentFrame".format(vray_mat))
+
+        # Set surface shader input
+        cmds.connectAttr("{}.outColor".format(vray_mat),
+                         "{}.surfaceShader".format(vray_mat_sg))
+
+        # Connect mesh to shader
+        cmds.sets([mesh_shape], addElement=vray_mat_sg)
+
+        group_node = cmds.group(empty=True, name="{}_GRP".format(name))
+        mesh_transform = cmds.listRelatives(mesh_shape,
+                                            parent=True, fullPath=True)
+        cmds.parent(mesh_transform, group_node)
+
+        nodes = [vray_mesh, mesh_shape, vray_mat, vray_mat_sg, group_node]
+
+        return nodes

--- a/colorbleed/plugins/maya/publish/extract_vrayproxy.py
+++ b/colorbleed/plugins/maya/publish/extract_vrayproxy.py
@@ -1,0 +1,60 @@
+import os
+
+import avalon.maya
+import colorbleed.api
+
+from maya import cmds
+
+
+class ExtractVRayProxy(colorbleed.api.Extractor):
+    """Extract the content of the instance to a vrmesh file
+
+    Things to pay attention to:
+        - If animation is toggled, are the frames correct
+        -
+    """
+
+    label = "VRay Proxy (.vrmesh)"
+    hosts = ["maya"]
+    families = ["colorbleed.vrayproxy"]
+
+    def process(self, instance):
+
+        staging_dir = self.staging_dir(instance)
+        file_name = "{}.vrmesh".format(instance.name)
+        file_path = os.path.join(staging_dir, file_name)
+
+        anim_on = instance.data["animation"]
+        if not anim_on:
+            # Remove animation information because it is not required for
+            # non-animated subsets
+            instance.data.pop("startFrame", None)
+            instance.data.pop("endFrame", None)
+
+            start_frame = 1
+            end_frame = 1
+        else:
+            start_frame = instance.data["startFrame"]
+            end_frame = instance.data["endFrame"]
+
+        # Write out vrmesh file
+        self.log.info("Writing: '%s'" % file_path)
+        with avalon.maya.maintained_selection():
+            cmds.select(instance.data["setMembers"], noExpand=True)
+            cmds.vrayCreateProxy(exportType=1,
+                                 dir=staging_dir,
+                                 fname=file_name,
+                                 animOn=anim_on,
+                                 animType=3,
+                                 startFrame=start_frame,
+                                 endFrame=end_frame,
+                                 ignoreHiddenObjects=True,
+                                 createProxyNode=False)
+
+        if "files" not in instance.data:
+            instance.data["files"] = list()
+
+        instance.data["files"].append(file_name)
+
+        self.log.info("Extracted instance '%s' to: %s"
+                      % (instance.name, staging_dir))

--- a/colorbleed/plugins/maya/publish/validate_vrayproxy.py
+++ b/colorbleed/plugins/maya/publish/validate_vrayproxy.py
@@ -1,0 +1,27 @@
+import pyblish.api
+
+
+class ValidateVrayProxy(pyblish.api.InstancePlugin):
+
+    order = pyblish.api.ValidatorOrder
+    label = 'VRay Proxy Settings'
+    hosts = ['maya']
+    families = ['colorbleed.vrayproxy']
+
+    def process(self, instance):
+
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise RuntimeError("'%s' has invalid settings for VRay Proxy "
+                               "export!" % instance.name)
+
+    @classmethod
+    def get_invalid(cls, instance):
+        data = instance.data
+
+        if not data["setMembers"]:
+            cls.log.error("'%s' is empty! This is a bug" % instance.name)
+
+        if data["animation"]:
+            if data["endFrame"] < data["startFrame"]:
+                cls.log.error("End frame is smaller than start frame")


### PR DESCRIPTION
A very rudemantry introdcution of VRay proxies (VRayMesh and VRayMeshMaterial) in to the pipeline.
The user will be able to export a piece of geometry with or without shaders to a `.vrmesh` extension which is optimized for mass rendering in VRay.

Currently supported:
* Creating a `vrayproxy` instance
* Validating and Extracting `vrayproxy` into the database and server
* Loading of `vrayproxy` in to Maya.