### PR TITLE
Show Workfiles on launch.

### DIFF
--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -5,6 +5,7 @@ import weakref
 from maya import utils, cmds, mel
 
 from avalon import api as avalon, pipeline, maya
+from avalon.tools import workfiles
 from pyblish import api as pyblish
 
 from ..lib import (
@@ -95,6 +96,16 @@ def on_init(_):
 
     from .customize import override_component_mask_commands
     safe_deferred(override_component_mask_commands)
+    safe_deferred(show_workfiles)
+
+
+def show_workfiles():
+    workfiles.show(
+        os.path.join(
+            cmds.workspace(query=True, rootDirectory=True),
+            cmds.workspace(fileRuleEntry="scene")
+        )
+    )
 
 
 def on_before_save(return_code, _):


### PR DESCRIPTION
This PR is just a suggestion, so feel free to close it.

I figured Colorbleed might be faster at testing this app, than I would since you have more people running Avalon on a daily basis.

This does require an update of the core.