### PR TITLE
Added support for frames per task

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_renderglobals.py
+++ b/colorbleed/plugins/maya/create/colorbleed_renderglobals.py
@@ -41,6 +41,7 @@ class CreateRenderGlobals(avalon.maya.Creator):
         data["overrideExistingFrame"] = True
         data["useLegacyRenderLayers"] = True
         data["priority"] = 50
+        data["framesPerTask"] = 1
         data["whitelist"] = False
         data["machineList"] = ""
         data["useMayaBatch"] = True

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -147,6 +147,9 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
         state = "Suspended" if attributes["suspendPublishJob"] else "Active"
         options["publishJobState"] = state
 
+        chunksize = attributes.get("framesPerTask", 1)
+        options["renderGlobals"]["ChunkSize"] = chunksize
+
         # Override frames should be False if extendFrames is False. This is
         # to ensure it doesn't go off doing crazy unpredictable things
         override_frames = False


### PR DESCRIPTION
Resolves issue REN-43

This PR will allow the user to control the amount of frames which are rendered by a machine per task.
In order to do this the user can set the required amount of frames in the Frames Per Task attribute of the render globals instance.

Instance in Maya:
[![Image from Gyazo](https://i.gyazo.com/e85a6dc7e6e49883e271ad84cfa0f29a.png)](https://gyazo.com/e85a6dc7e6e49883e271ad84cfa0f29a)

Result in Deadline:
[![Image from Gyazo](https://i.gyazo.com/ce2e8203b43276d9b70ac4ffc7977cfa.png)](https://gyazo.com/ce2e8203b43276d9b70ac4ffc7977cfa)

Details:
The instance has a nice name for the user `Frames Per Task`, in the `collect_renderlayer` plugin the instance is read and will translate the attribute `framesPerTask` to `ChunkSize` for the Deadline submission