### PR TITLE
Add control for samples, Yeti

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_yeti_cache.py
+++ b/colorbleed/plugins/maya/create/colorbleed_yeti_cache.py
@@ -15,11 +15,12 @@ class CreateYetiCache(avalon.maya.Creator):
     def __init__(self, *args, **kwargs):
         super(CreateYetiCache, self).__init__(*args, **kwargs)
 
-        data = OrderedDict(self.data)
+        data = OrderedDict(**self.data)
         data["peroll"] = 0
 
         anim_data = lib.collect_animation_data()
         data.update({"startFrame": anim_data["startFrame"],
-                     "endFrame": anim_data["endFrame"]})
+                     "endFrame": anim_data["endFrame"],
+                     "samples": 3})
 
         self.data = data

--- a/colorbleed/plugins/maya/publish/extract_yeti_cache.py
+++ b/colorbleed/plugins/maya/publish/extract_yeti_cache.py
@@ -37,6 +37,13 @@ class ExtractYetiCache(colorbleed.api.Extractor):
         if preroll > 0:
             start_frame -= preroll
 
+        kwargs = {}
+        samples = instance.data.get("samples", 0)
+        if samples == 0:
+            kwargs.update({"sampleTimes": "0.0 1.0"})
+        else:
+            kwargs.update({"samples": samples})
+
         self.log.info("Writing out cache")
         # Start writing the files for snap shot
         # <NAME> will be replace by the Yeti node name
@@ -44,9 +51,9 @@ class ExtractYetiCache(colorbleed.api.Extractor):
         cmds.pgYetiCommand(yeti_nodes,
                            writeCache=path,
                            range=(start_frame, end_frame),
-                           sampleTimes="0.0 1.0",
                            updateViewport=False,
-                           generatePreview=False)
+                           generatePreview=False,
+                           **kwargs)
 
         cache_files = [x for x in os.listdir(dirname) if x.endswith(".fur")]
 


### PR DESCRIPTION
Resolves issue YETI-7

Adds the option for the user to set the amount of sample for the Yeti cache.
If the attribute value is zero it will fallback to `sampleTimes : 0.0 1.0`, its default value is 3 which is similar to the default settings of the pgYetiMaya node,

* Added attribute to the instance
* Added support and backwards compatibility