### PR TITLE
Force forward slashes for resource destination values

### DIFF
--- a/colorbleed/plugins/global/publish/collect_assumed_destination.py
+++ b/colorbleed/plugins/global/publish/collect_assumed_destination.py
@@ -35,6 +35,12 @@ class CollectAssumedDestination(pyblish.api.InstancePlugin):
             # Add destination to the resource
             source_filename = os.path.basename(resource["source"])
             destination = os.path.join(mock_destination, source_filename)
+
+            # Force forward slashes to fix issue with software unable
+            # to work correctly with backslashes in specific scenarios
+            # (e.g. escape characters in PLN-151 V-Ray UDIM)
+            destination = destination.replace("\\", "/")
+
             resource['destination'] = destination
 
             # Collect transfers for the individual files of the resource


### PR DESCRIPTION
This should fix PLN-151 + PLN-89. The unfortunate issue was that with backslashes in the image file path for Maya nodes the renderer might mess up on characters like `\r` because they are escape character. By forcing forward slashes that issue should be gone.