### PR TITLE
Add on_new callback for Maya

### DIFF
--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -257,16 +257,33 @@ def get_project_fps():
 
     Returns:
         int, float
+
+    """
+
+    data = get_project_data()
+    fps = data.get("fps", 25.0)
+
+    return fps
+
+
+def get_project_data():
+    """Get the data of the current project
+
+    The data of the project can contain things like:
+        resolution
+        fps
+        renderer
+
+    Returns:
+        dict:
+
     """
 
     project_name = io.active_project()
     project = io.find_one({"name": project_name,
                            "type": "project"},
-                          projection={"config": True})
+                          projection={"data": True})
 
-    config = project.get("config", None)
-    assert config, "This is a bug"
+    data = project.get("data", {})
 
-    fps = config.get("fps", 25.0)
-
-    return fps
+    return data

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -306,17 +306,3 @@ def get_asset_data(asset=None):
     data = document.get("data", {})
 
     return data
-
-
-def get_asset_fps():
-    """Return the FPS from the asset data if found else None
-
-    Returns:
-        int, float, None
-
-    """
-
-    data = get_asset_data()
-    fps = data.get("fps", None)
-
-    return fps

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -289,9 +289,17 @@ def get_project_data():
     return data
 
 
-def get_asset_data():
+def get_asset_data(asset=None):
+    """Get the data from the current asset
+
+    Args:
+        asset(str, Optional): name of the asset, eg:
+
+    Returns:
+        dict
+    """
     
-    asset_name = avalon.api.Session["AVALON_ASSET"]
+    asset_name = asset or avalon.api.Session["AVALON_ASSET"]
     document = io.find_one({"name": asset_name,
                             "type": "asset"})
 
@@ -301,6 +309,12 @@ def get_asset_data():
 
 
 def get_asset_fps():
+    """Return the FPS from the asset data if found else None
+
+    Returns:
+        int, float, None
+
+    """
 
     data = get_asset_data()
     fps = data.get("fps", None)

--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -287,3 +287,22 @@ def get_project_data():
     data = project.get("data", {})
 
     return data
+
+
+def get_asset_data():
+    
+    asset_name = avalon.api.Session["AVALON_ASSET"]
+    document = io.find_one({"name": asset_name,
+                            "type": "asset"})
+
+    data = document.get("data", {})
+
+    return data
+
+
+def get_asset_fps():
+
+    data = get_asset_data()
+    fps = data.get("fps", None)
+
+    return fps

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -162,9 +162,9 @@ def on_open(_):
 
 def on_new(_):
     """Set project resolution and fps when create a new file"""
-
+    avalon.logger.info("Running callback on new..")
     with maya.suspended_refresh():
-        lib.set_project_settings()
+        lib.set_context_settings()
 
 
 def on_task_changed(*args):

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -39,6 +39,8 @@ def install():
 
     avalon.before("save", on_before_save)
 
+    avalon.on("new", on_new)
+
     log.info("Overriding existing event 'taskChanged'")
     override_event("taskChanged", on_task_changed)
 
@@ -156,6 +158,13 @@ def on_open(_):
                               "your Maya scene.")
             dialog.on_show.connect(_on_show_inventory)
             dialog.show()
+
+
+def on_new(_):
+    """Set project resolution and fps when create a new file"""
+
+    with maya.suspended_refresh():
+        lib.set_project_settings()
 
 
 def on_task_changed(*args):

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1371,6 +1371,7 @@ def get_id_from_history(node):
             return _id
 
 
+# Project settings
 def set_scene_fps(fps, update=True):
     """Set FPS from project configuration
 
@@ -1397,6 +1398,58 @@ def set_scene_fps(fps, update=True):
 
     # Force file stated to 'modified'
     cmds.file(modified=True)
+
+
+def set_scene_resolution(resolution, renderer):
+    """Set the render resolution
+
+    Args:
+        resolution(str): <width>x<heigth>, eg: '1920x1080'
+        renderer(str): name of the curren renderer; vray / redshift / arnold
+
+    Returns:
+        bool: True if successful
+
+    """
+
+    control_node = "defaultResolution"
+    cmds.setAttr("defaultRenderGlobals.currentRenderer",
+                 renderer,
+                 type="string")
+
+    width, height = resolution.split("x")
+
+    # Give VRay a helping hand as it is slightly different from the rest
+    if renderer == "vray":
+        control_node = "vraySettings"
+        if not cmds.objExists(type=control_node):
+            cmds.createNode("VRaySettingsNode", name=control_node)
+
+    cmds.setAttr("%s.width" % control_node, int(width))
+    cmds.setAttr("%s.height" % control_node, int(height))
+
+    log.info("Set project resolution to: %s" % resolution)
+
+    return True
+
+
+def set_project_settings():
+    """Apply the project settings from the project definition
+
+    Returns:
+        None
+    """
+
+    # Todo (Wijnand): apply renderer and resolution of project
+
+    # Get project settings
+    data = lib.get_project_data()
+    fps = data.get("fps", None)
+
+    if fps is None:
+        return
+
+    set_scene_fps(fps)
 
 
 # Valid FPS

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1450,9 +1450,7 @@ def set_context_settings():
     asset_data = lib.get_asset_data()
 
     # Set project fps
-    fps = asset_data.get("fps", project_data.get("fps", None))
-    if fps is None:
-        return
+    fps = asset_data.get("fps", project_data.get("fps", 25))
     set_scene_fps(fps)
 
     # Set project resolution
@@ -1474,7 +1472,8 @@ def validate_fps():
 
     """
 
-    fps = lib.get_project_fps()  # can be int or float
+    asset_data = lib.get_asset_data()
+    fps = asset_data.get("fps", lib.get_project_fps())  # can be int or float
     current_fps = mel.eval('currentTimeUnitToFPS()')  # returns float
 
     if current_fps != fps:

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1385,11 +1385,10 @@ def set_scene_fps(fps, update=True):
     """
 
     if fps in FLOAT_FPS:
-        # :.2f means <any digits>.<round to 2 digits>
-        unit = "{:.2f}fps".format(fps)
+        unit = "{}fps".format(fps)
 
     elif fps in INT_FPS:
-        unit = "{:d}fps".format(int(fps))
+        unit = "{}fps".format(int(fps))
 
     else:
         raise ValueError("Unsupported FPS value: `%s`" % fps)

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1423,7 +1423,9 @@ def set_scene_resolution(resolution, renderer):
     if renderer == "vray":
         control_node = "vraySettings"
         if not cmds.objExists(type=control_node):
-            cmds.createNode("VRaySettingsNode", name=control_node)
+            log.error("Cannot set resolution because there is no node named:"
+                      "`%s`" % control_node)
+            return
 
     cmds.setAttr("%s.width" % control_node, int(width))
     cmds.setAttr("%s.height" % control_node, int(height))
@@ -1451,8 +1453,9 @@ def set_context_settings():
     # Todo (Wijnand): apply renderer and resolution of project
 
     # Get project settings
-    data = lib.get_project_data()
-    fps = lib.get_asset_fps() or data.get("fps", None)
+    project_data = lib.get_project_data()
+    asset_data = lib.get_asset_data()
+    fps = asset_data.get("fps", project_data.get("fps", None))
     if fps is None:
         return
 

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1433,8 +1433,16 @@ def set_scene_resolution(resolution, renderer):
     return True
 
 
-def set_project_settings():
+def set_context_settings():
     """Apply the project settings from the project definition
+
+    Settings can be overwritten by an asset if the asset.data contains
+    any information regarding those settings.
+
+    Examples of settings:
+        fps
+        resolution
+        renderer
 
     Returns:
         None
@@ -1444,8 +1452,7 @@ def set_project_settings():
 
     # Get project settings
     data = lib.get_project_data()
-    fps = data.get("fps", None)
-
+    fps = lib.get_asset_fps() or data.get("fps", None)
     if fps is None:
         return
 


### PR DESCRIPTION
Resolves issue PLN-159

__Note: This requires the projects to be reconfigured. fps will need to move to `project.data`__

In order to ensure that the user's project settings are applied after launching Maya we added the `on_new` callback which will apply the project's settings such as FPS and resolution.

This PR also introduces a minor refactoring in the way the project information is being queried. By adding the `get_project_data` we reduce the number of specific calls which eventually are stored in the same `data`.

The `get_project_fps` will call `get_project_data` first and then retrieve the FPS out of it. The idea is to get and set all other relevant settings when launching Maya.
