### PR TITLE
Minor fixes for FPS + renderlayers + renderlayer nice label names

### DIFF
--- a/colorbleed/lib.py
+++ b/colorbleed/lib.py
@@ -252,7 +252,7 @@ def collect_container_metadata(container):
     return hostlib.get_additional_data(container)
 
 
-def get_project_fps():
+def get_asset_fps():
     """Returns project's FPS, if not found will return 25 by default
 
     Returns:
@@ -260,10 +260,20 @@ def get_project_fps():
 
     """
 
-    data = get_project_data()
-    fps = data.get("fps", 25.0)
+    key = "fps"
 
-    return fps
+    # FPS from asset data (if set)
+    asset_data = get_asset_data()
+    if key in asset_data:
+        return asset_data[key]
+
+    # FPS from project data (if set)
+    project_data = get_project_data()
+    if key in project_data:
+        return project_data[key]
+
+    # Fallback to 25 FPS
+    return 25.0
 
 
 def get_project_data():
@@ -298,7 +308,7 @@ def get_asset_data(asset=None):
     Returns:
         dict
     """
-    
+
     asset_name = asset or avalon.api.Session["AVALON_ASSET"]
     document = io.find_one({"name": asset_name,
                             "type": "asset"})

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -128,11 +128,12 @@ def on_open(_):
     from avalon.vendor.Qt import QtWidgets
     from ..widgets import popup
 
-    # Ensure scene's FPS is set to project config
-    lib.validate_fps()
-
     # Update current task for the current scene
     update_task_from_path(cmds.file(query=True, sceneName=True))
+
+    # Validate FPS after update_task_from_path to
+    # ensure it is using correct FPS for the asset
+    lib.validate_fps()
 
     if any_outdated():
         log.warning("Scene has outdated content.")

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1472,8 +1472,7 @@ def validate_fps():
 
     """
 
-    asset_data = lib.get_asset_data()
-    fps = asset_data.get("fps", lib.get_project_fps())  # can be int or float
+    fps = lib.get_asset_fps()
     current_fps = mel.eval('currentTimeUnitToFPS()')  # returns float
 
     if current_fps != fps:

--- a/colorbleed/plugins/maya/publish/collect_render_layer_aovs.py
+++ b/colorbleed/plugins/maya/publish/collect_render_layer_aovs.py
@@ -41,7 +41,7 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
 
         self.log.info("Renderer found: {}".format(renderer))
 
-        rp_node_types = {"vray": "VRayRenderElement",
+        rp_node_types = {"vray": ("VRayRenderElement", "VRayRenderElementSet"),
                          "arnold": "aiAOV",
                          "redshift": "RedshiftAOV"}
 
@@ -52,7 +52,8 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
         result = []
 
         # Collect all AOVs / Render Elements
-        with lib.renderlayer(instance.name):
+        layer = instance.data["setMembers"]
+        with lib.renderlayer(layer):
 
             node_type = rp_node_types[renderer]
             render_elements = cmds.ls(type=node_type)
@@ -64,32 +65,36 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
                     continue
 
                 pass_name = self.get_pass_name(renderer, element)
-                render_pass = "%s.%s" % (instance.name, pass_name)
+                render_pass = "%s.%s" % (instance.data["subset"], pass_name)
 
                 result.append(render_pass)
 
         self.log.info("Found {} render elements / AOVs for "
-                      "'{}'".format(len(result), instance.name))
+                      "'{}'".format(len(result), instance.data["subset"]))
 
         instance.data["renderPasses"] = result
 
     def get_pass_name(self, renderer, node):
 
         if renderer == "vray":
+
+            # Get render element pass type
             vray_node_attr = next(attr for attr in cmds.listAttr(node)
                                   if attr.startswith("vray_name"))
-
             pass_type = vray_node_attr.rsplit("_", 1)[-1]
+
+            # Support V-Ray extratex explicit name (if set by user)
             if pass_type == "extratex":
-                vray_node_attr = "vray_explicit_name_extratex"
+                explicit_attr = "{}.vray_explicit_name_extratex".format(node)
+                explicit_name = cmds.getAttr(explicit_attr)
+                if explicit_name:
+                    return explicit_name
 
             # Node type is in the attribute name but we need to check if value
             # of the attribute as it can be changed
-            pass_name = cmds.getAttr("{}.{}".format(node, vray_node_attr))
+            return cmds.getAttr("{}.{}".format(node, vray_node_attr))
 
         elif renderer in ["arnold", "redshift"]:
-            pass_name = cmds.getAttr("{}.name".format(node))
+            return cmds.getAttr("{}.name".format(node))
         else:
             raise RuntimeError("Unsupported renderer: '{}'".format(renderer))
-
-        return pass_name

--- a/colorbleed/plugins/maya/publish/collect_render_layer_aovs.py
+++ b/colorbleed/plugins/maya/publish/collect_render_layer_aovs.py
@@ -41,9 +41,9 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
 
         self.log.info("Renderer found: {}".format(renderer))
 
-        rp_node_types = {"vray": ("VRayRenderElement", "VRayRenderElementSet"),
-                         "arnold": "aiAOV",
-                         "redshift": "RedshiftAOV"}
+        rp_node_types = {"vray": ["VRayRenderElement", "VRayRenderElementSet"],
+                         "arnold": ["aiAOV"],
+                         "redshift": ["RedshiftAOV"]}
 
         if renderer not in rp_node_types.keys():
             self.log.error("Unsupported renderer found: '{}'".format(renderer))

--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -103,7 +103,12 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
             overrides = self.parse_options(render_globals)
             data.update(**overrides)
 
-            instance = context.create_instance(layername)
+            # Define nice label
+            label = "{0} ({1})".format(layername, data["asset"])
+            label += "  [{0}-{1}]".format(int(data["startFrame"]),
+                                          int(data["endFrame"]))
+
+            instance = context.create_instance(label)
             instance.data.update(data)
 
     def get_render_attribute(self, attr):

--- a/colorbleed/plugins/maya/publish/submit_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_deadline.py
@@ -115,7 +115,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         scene = os.path.splitext(filename)[0]
         dirname = os.path.join(workspace, "renders")
         renderlayer = instance.data['setMembers']       # rs_beauty
-        renderlayer_name = instance.name                # beauty
+        renderlayer_name = instance.data['subset']      # beauty
         renderlayer_globals = instance.data["renderGlobals"]
         legacy_layers = renderlayer_globals["UseLegacyRenderLayers"]
         deadline_user = context.data.get("deadlineUser", getpass.getuser())

--- a/colorbleed/plugins/maya/publish/validate_maya_units.py
+++ b/colorbleed/plugins/maya/publish/validate_maya_units.py
@@ -16,11 +16,12 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
+        # Collected units
         linearunits = context.data('linearUnits')
         angularunits = context.data('angularUnits')
-
         fps = context.data['fps']
-        project_fps = lib.get_project_fps()
+
+        asset_fps = lib.get_asset_fps()
 
         self.log.info('Units (linear): {0}'.format(linearunits))
         self.log.info('Units (angular): {0}'.format(angularunits))
@@ -32,7 +33,7 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
 
         assert angularunits and angularunits == 'deg', ("Scene angular units "
                                                         "must be degrees")
-        assert fps and fps == project_fps, "Scene must be %s FPS" % project_fps
+        assert fps and fps == asset_fps, "Scene must be %s FPS" % asset_fps
 
     @classmethod
     def repair(cls):
@@ -49,5 +50,5 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         cls.log.debug(current_linear)
 
         cls.log.info("Setting time unit to match project")
-        project_fps = lib.get_project_fps()
-        mayalib.set_scene_fps(project_fps)
+        asset_fps = lib.get_asset_fps()
+        mayalib.set_scene_fps(asset_fps)


### PR DESCRIPTION
Some fixes for the pipeline:

- Validate FPS on scene open after updating the task from the new scene so it tries to validate with the correct asset.
- FPS publish check to also use asset fps settings from database
- Fix getting AOVs code for Maya+V-Ray (support light select set node and non-explicit named extratex)
- Add nice label name for collecting renderlayers in Pyblish+Maya (with asset name and frame name)