### PR TITLE
Hot fix

### DIFF
--- a/colorbleed/plugins/maya/load/load_yeti_cache.py
+++ b/colorbleed/plugins/maya/load/load_yeti_cache.py
@@ -284,6 +284,8 @@ class YetiCacheLoader(api.Loader):
 
             # Apply attributes to pgYetiMaya node
             for attr, value in attributes.items():
+                if value is None:
+                    continue
                 lib.set_attribute(attr, value, yeti_node)
 
             # Fix for : YETI-6


### PR DESCRIPTION
A NoneType value was causing the following problem:

```
# Traceback (most recent call last):
#   File "C:\Users\Guest4\Development\colorbleed\core\avalon\tools\cbloader\widgets.py", line 201, in on_context_menu
#     api.load(Loader=loader, representation=representation['_id'])
#   File "C:\Users\Guest4\Development\colorbleed\core\avalon\pipeline.py", line 1040, in load
#     data=data)
#   File "<string>", line 48, in load
#   File "<string>", line 289, in create_nodes
#   File "C:\Users\Guest4\Development\colorbleed\config\colorbleed\maya\lib.py", line 896, in set_attribute
#     kwargs = ATTRIBUTE_DICT[value_type]
# KeyError: 'NoneType'
```

Added check for value before passing value to `lib.set_attribute`