### PR TITLE
Fix #142 - allow to ignore menu install on missing "scriptsmenu"

### DIFF
--- a/colorbleed/maya/menu.py
+++ b/colorbleed/maya/menu.py
@@ -23,10 +23,15 @@ def _get_menu():
 
 def deferred():
 
-    import scriptsmenu.launchformaya as launchformaya
-    import scriptsmenu.scriptsmenu as scriptsmenu
+    log.info("Attempting to install scripts menu..")
 
-    log.info("Attempting to install ...")
+    try:
+        import scriptsmenu.launchformaya as launchformaya
+        import scriptsmenu.scriptsmenu as scriptsmenu
+    except ImportError:
+        log.warning("Skipping colorbleed.menu install, because "
+                    "'scriptsmenu' module seems unavailable.")
+        return
 
     # load configuration of custom menu
     config_path = os.path.join(os.path.dirname(__file__), "menu.json")
@@ -44,7 +49,7 @@ def uninstall():
 
     menu = _get_menu()
     if menu:
-        log.info("Attempting to uninstall ..")
+        log.info("Attempting to uninstall..")
 
         try:
             menu.deleteLater()


### PR DESCRIPTION
This allows to ignore colorbleed scripts menu installation when `scriptsmenu` cannot be imported (likely because of the missing dependency) as a workaround for #142

