### PR TITLE
Improve collect animation

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_animation.py
+++ b/colorbleed/plugins/maya/publish/collect_animation.py
@@ -29,8 +29,11 @@ class CollectAnimationOutputGeometry(pyblish.api.InstancePlugin):
         out_set = next((i for i in instance.data["setMembers"] if
                         i.endswith("out_SET")), None)
 
-        assert out_set, ("Expecting out_SET for instance of family"
-                         " '%s'" % family)
+        if out_set is None:
+            warning = "Expecting out_SET for instance of family '%s'" % family
+            self.log.warning(warning)
+            return
+
         members = cmds.ls(cmds.sets(out_set, query=True), long=True)
 
         # Get all the relatives of the members


### PR DESCRIPTION
Fixes ANM-13

Throw warning instead of assertion error. 

This fix will support the ability for animators to unload referenced rigs if scene become too heavy and still be able to publish the other content.