### PR TITLE
Explicit check for animation content

### DIFF
--- a/colorbleed/plugins/maya/publish/validate_animation_content.py
+++ b/colorbleed/plugins/maya/publish/validate_animation_content.py
@@ -23,8 +23,10 @@ class ValidateAnimationContent(pyblish.api.InstancePlugin):
         out_set = next((i for i in instance.data["setMembers"] if
                         i.endswith("out_SET")), None)
 
-        assert out_set, ("Instance '%s' has no objectSet named: `OUT_set`" %
-                         instance.name)
+        assert out_set, ("Instance '%s' has no objectSet named: `OUT_set`."
+                         "If this instance is an unloaded reference, "
+                         "please deactivate by toggling the 'Active' attribute"
+                         % instance.name)
 
         # All nodes in the `out_hierarchy` must be among the nodes that are
         # in the instance. The nodes in the instance are found from the top

--- a/colorbleed/plugins/maya/publish/validate_animation_content.py
+++ b/colorbleed/plugins/maya/publish/validate_animation_content.py
@@ -22,7 +22,7 @@ class ValidateAnimationContent(pyblish.api.InstancePlugin):
         out_set = next((i for i in instance.data["setMembers"] if
                         i.endswith("out_SET")), None)
 
-        assert out_set, ("Instance '%s' has no objectSet named: `OUT_set`."
+        assert out_set, ("Instance '%s' has no objectSet named: `OUT_set`. "
                          "If this instance is an unloaded reference, "
                          "please deactivate by toggling the 'Active' attribute"
                          % instance.name)

--- a/colorbleed/plugins/maya/publish/validate_animation_content.py
+++ b/colorbleed/plugins/maya/publish/validate_animation_content.py
@@ -20,6 +20,12 @@ class ValidateAnimationContent(pyblish.api.InstancePlugin):
     def get_invalid(cls, instance):
         assert 'out_hierarchy' in instance.data, "Missing `out_hierarchy` data"
 
+        out_set = next((i for i in instance.data["setMembers"] if
+                        i.endswith("out_SET")), None)
+
+        assert out_set, ("Instance '%s' has no objectSet named: `OUT_set`" %
+                         instance.name)
+
         # All nodes in the `out_hierarchy` must be among the nodes that are
         # in the instance. The nodes in the instance are found from the top
         # group, as such this tests whether all nodes are under that top group.

--- a/colorbleed/plugins/maya/publish/validate_animation_content.py
+++ b/colorbleed/plugins/maya/publish/validate_animation_content.py
@@ -18,7 +18,6 @@ class ValidateAnimationContent(pyblish.api.InstancePlugin):
 
     @classmethod
     def get_invalid(cls, instance):
-        assert 'out_hierarchy' in instance.data, "Missing `out_hierarchy` data"
 
         out_set = next((i for i in instance.data["setMembers"] if
                         i.endswith("out_SET")), None)
@@ -27,6 +26,8 @@ class ValidateAnimationContent(pyblish.api.InstancePlugin):
                          "If this instance is an unloaded reference, "
                          "please deactivate by toggling the 'Active' attribute"
                          % instance.name)
+
+        assert 'out_hierarchy' in instance.data, "Missing `out_hierarchy` data"
 
         # All nodes in the `out_hierarchy` must be among the nodes that are
         # in the instance. The nodes in the instance are found from the top


### PR DESCRIPTION
With the previous PR we resolved the issue of unloaded references throwing errors due to missing out_SETS. To ensure active instances with unloaded references are still being caught I added a check for the out_SET to the `validate_animation_content`.

The error message given contains a solution for the artist.