### PR TITLE
Fixed bug in assertion

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -26,7 +26,7 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        assert "input_SET" in cmds.sets(instance.name, query=True), (
+        assert "input_SET" in instance.data["setMembers"], (
             "Yeti Rig must have an input_SET")
 
         # Get the input meshes information


### PR DESCRIPTION
Issue spotted by the artist.

`instance.name` is a nice name since this [PR](https://github.com/Colorbleed/colorbleed-config/pull/154) there for it threw a warning.

Fixed it by passing the `instance.data["setMembers"]`