### PR TITLE
Improve validate fps

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1404,8 +1404,18 @@ def set_scene_fps(fps, update=True):
     else:
         raise ValueError("Unsupported FPS value: `%s`" % fps)
 
+    # Get time slider current state
+    start_frame = cmds.playbackOptions(query=True, minTime=True)
+    end_frame = cmds.playbackOptions(query=True, maxTime=True)
+    current_frame = cmds.currentTime(query=True)
+
     log.info("Updating FPS to '{}'".format(unit))
     cmds.currentUnit(time=unit, updateAnimation=update)
+
+    # Set time slider data back to previous state
+    cmds.playbackOptions(edit=True, minTime=start_frame)
+    cmds.playbackOptions(edit=True, maxTime=end_frame)
+    cmds.currentTime(current_frame, edit=True, update=True)
 
     # Force file stated to 'modified'
     cmds.file(modified=True)

--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -1407,6 +1407,11 @@ def set_scene_fps(fps, update=True):
     # Get time slider current state
     start_frame = cmds.playbackOptions(query=True, minTime=True)
     end_frame = cmds.playbackOptions(query=True, maxTime=True)
+
+    # Get animation data
+    animation_start = cmds.playbackOptions(query=True, animationStartTime=True)
+    animation_end = cmds.playbackOptions(query=True, animationEndTime=True)
+
     current_frame = cmds.currentTime(query=True)
 
     log.info("Updating FPS to '{}'".format(unit))
@@ -1415,6 +1420,11 @@ def set_scene_fps(fps, update=True):
     # Set time slider data back to previous state
     cmds.playbackOptions(edit=True, minTime=start_frame)
     cmds.playbackOptions(edit=True, maxTime=end_frame)
+
+    # Set animation data
+    cmds.playbackOptions(edit=True, animationStartTime=animation_start)
+    cmds.playbackOptions(edit=True, animationEndTime=animation_end)
+
     cmds.currentTime(current_frame, edit=True, update=True)
 
     # Force file stated to 'modified'


### PR DESCRIPTION
Resolved ANM-14

In order to maintain as much animation settings the `set_scene_fps` function has been improved.
This PR will maintain the following settings:

* Animation start and end frame
* Time slider start and end frame (minTime, maxTime)
* Current frame

It will allow the artist to update without having to worry about unrounded floats like `0.96` or `115.48`