### PR TITLE
Fix PLN-149 for Deadline renders, avoid Redshift creating .lock files

### DIFF
--- a/colorbleed/plugins/maya/publish/submit_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_deadline.py
@@ -207,6 +207,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             # todo: This is a temporary fix for yeti variables
             "PEREGRINEL_LICENSE",
             "REDSHIFT_MAYAEXTENSIONSPATH",
+            "REDSHIFT_DISABLEOUTPUTLOCKFILES"
             "VRAY_FOR_MAYA2018_PLUGINS_X64",
             "VRAY_PLUGINS_X64",
             "VRAY_USE_THREAD_AFFINITY",


### PR DESCRIPTION
Also fix this for Deadline renders by transferring the variable with the submissions.