### PR TITLE
Add render callback validator

### DIFF
--- a/colorbleed/plugins/maya/publish/validate_renderscript_callbacks.py
+++ b/colorbleed/plugins/maya/publish/validate_renderscript_callbacks.py
@@ -61,25 +61,25 @@ class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
         pre_render_callback = cmds.getAttr("defaultRenderGlobals.preMel")
         post_render_callback = cmds.getAttr("defaultRenderGlobals.postMel")
 
+        pre_callbacks = pre_render_callback.split(";")
+        post_callbacks = post_render_callback.split(";")
+
         pre_script = callback_lookup.get("pre", "")
         post_script = callback_lookup.get("post", "")
 
         # If not loaded
         if not yeti_loaded:
-            if pre_script and pre_script in pre_render_callback:
-                cls.log.error(
-                    "Found pre render callback which is not uses!"
-                )
+            if pre_script and pre_script in pre_callbacks:
+                cls.log.error("Found pre render callback '%s' which is not "
+                              "uses!" % pre_script)
                 invalid = True
 
-            if post_script and post_script in post_render_callback:
-                cls.log.error(
-                    "Found post render callback which is not used!"
-                )
+            if post_script and post_script in post_callbacks:
+                cls.log.error("Found post render callback '%s which is "
+                              "not used!" % post_script)
                 invalid = True
         else:
             if pre_script:
-                pre_callbacks = pre_render_callback.split(";")
                 if pre_script not in pre_callbacks:
                     cls.log.error(
                         "Could not find required pre render callback "
@@ -87,7 +87,6 @@ class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
                     invalid = True
 
             if post_script:
-                post_callbacks = post_render_callback.split(";")
                 if post_script not in post_callbacks:
                     cls.log.error("Could not find required post render callback"
                                   " `%s`" % post_script)

--- a/colorbleed/plugins/maya/publish/validate_renderscript_callbacks.py
+++ b/colorbleed/plugins/maya/publish/validate_renderscript_callbacks.py
@@ -1,0 +1,96 @@
+from maya import cmds
+
+import pyblish.api
+import colorbleed.api
+
+
+class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
+    """Check if the render script callbacks will be used during the rendering
+
+    In order to ensure the render tasks are executed properly we need to check
+    if the pre and post render callbacks are actually used.
+
+    For example:
+        Yeti is not loaded but its callback scripts are still set in the
+        render settings. This will cause an error because Maya tries to find
+        and execute the callbacks.
+
+    Developer note:
+         The pre and post render callbacks cannot be overridden
+
+    """
+
+    order = colorbleed.api.ValidateContentsOrder
+    label = "Render Script Callbacks"
+    hosts = ["maya"]
+    families = ["colorbleed.renderlayer"]
+
+    def process(self, instance):
+
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise ValueError("Invalid render callbacks found for '%s'!"
+                             % instance.name)
+
+    @classmethod
+    def get_invalid(cls, instance):
+
+        invalid = False
+
+        # lookup per render
+        render_scripts = {"vray":
+                              {"pre":  "catch(`pgYetiVRayPreRender`)",
+                               "post": "catch(`pgYetiVRayPostRender`)"},
+                          "arnold":
+                              {"pre": "pgYetiPreRender"}
+                          }
+
+        yeti_loaded = cmds.pluginInfo("pgYetiMaya", query=True, loaded=True)
+
+        renderer = instance.data["renderer"]
+        if renderer == "redshift":
+            cls.log.info("Redshift ignores any pre and post render callbacks")
+            return False
+
+        callback_lookup = render_scripts.get(renderer, {})
+        if not callback_lookup:
+            cls.log.error(
+                "Renderer '%s' is not supported in this plugin"  % renderer
+            )
+
+        pre_render_callback = cmds.getAttr("defaultRenderGlobals.preMel")
+        post_render_callback = cmds.getAttr("defaultRenderGlobals.postMel")
+
+        pre_script = callback_lookup.get("pre", "")
+        post_script = callback_lookup.get("post", "")
+
+        # If not loaded
+        if not yeti_loaded:
+            if pre_script and pre_script in pre_render_callback:
+                cls.log.error(
+                    "Found pre render callback which is not uses!"
+                )
+                invalid = True
+
+            if post_script and post_script in post_render_callback:
+                cls.log.error(
+                    "Found post render callback which is not used!"
+                )
+                invalid = True
+        else:
+            if pre_script:
+                pre_callbacks = pre_render_callback.split(";")
+                if pre_script not in pre_callbacks:
+                    cls.log.error(
+                        "Could not find required pre render callback "
+                        "`%s`" % pre_script)
+                    invalid = True
+
+            if post_script:
+                post_callbacks = post_render_callback.split(";")
+                if post_script not in post_callbacks:
+                    cls.log.error("Could not find required post render callback"
+                                  " `%s`" % post_script)
+                    invalid = True
+
+        return invalid

--- a/colorbleed/plugins/maya/publish/validate_renderscript_callbacks.py
+++ b/colorbleed/plugins/maya/publish/validate_renderscript_callbacks.py
@@ -35,8 +35,6 @@ class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
 
-        invalid = False
-
         # lookup per render
         render_scripts = {"vray":
                               {"pre":  "catch(`pgYetiVRayPreRender`)",
@@ -54,9 +52,9 @@ class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
 
         callback_lookup = render_scripts.get(renderer, {})
         if not callback_lookup:
-            cls.log.error(
-                "Renderer '%s' is not supported in this plugin"  % renderer
-            )
+            cls.log.warning("Renderer '%s' is not supported in this plugin"
+                            % renderer)
+            return False
 
         pre_render_callback = cmds.getAttr("defaultRenderGlobals.preMel")
         post_render_callback = cmds.getAttr("defaultRenderGlobals.postMel")
@@ -68,6 +66,7 @@ class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
         post_script = callback_lookup.get("post", "")
 
         # If not loaded
+        invalid = False
         if not yeti_loaded:
             if pre_script and pre_script in pre_callbacks:
                 cls.log.error("Found pre render callback '%s' which is not "

--- a/colorbleed/plugins/maya/publish/validate_yeti_renderscript_callbacks.py
+++ b/colorbleed/plugins/maya/publish/validate_yeti_renderscript_callbacks.py
@@ -4,7 +4,7 @@ import pyblish.api
 import colorbleed.api
 
 
-class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
+class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin):
     """Check if the render script callbacks will be used during the rendering
 
     In order to ensure the render tasks are executed properly we need to check
@@ -21,7 +21,7 @@ class ValidateRenderScriptCallbacks(pyblish.api.InstancePlugin):
     """
 
     order = colorbleed.api.ValidateContentsOrder
-    label = "Render Script Callbacks"
+    label = "Yeti Render Script Callbacks"
     hosts = ["maya"]
     families = ["colorbleed.renderlayer"]
 


### PR DESCRIPTION
Resolves internal issue PLN-120

In order to ensure the render tasks are executed properly we need to check if the pre and post render callbacks are actually used.

For example:
Yeti is not loaded but its callback scripts are still set in the render settings. This will cause an error because Maya tries to find and execute the callbacks.