### PR TITLE
Set primitve to detail pattern at creation

### DIFF
--- a/colorbleed/plugins/houdini/create/create_pointcache.py
+++ b/colorbleed/plugins/houdini/create/create_pointcache.py
@@ -22,7 +22,8 @@ class CreatePointCache(houdini.Creator):
 
         parms = {"use_sop_path": True,  # Export single node from SOP Path
                  "build_from_path": True,  # Direct path of primitive in output
-                 "path_attrib": "path",  # Pass path attribute for output
+                 "path_attrib": "path",  # Pass path attribute for output\
+                 "prim_to_detail_pattern": "cbId",
                  "format": 2,  # Set format to Ogawa
                  "filename": "$HIP/pyblish/%s.abc" % self.name}
 


### PR DESCRIPTION
Resolves internal issue PLN-176

At instance creation it will now set `prim_to_detail_pattern` to `cbId` .
This is needed to maintain the `cbId` after geometry is extracted.