### PR TITLE
Backwards compatible loader

### DIFF
--- a/colorbleed/plugins/houdini/load/load_alembic.py
+++ b/colorbleed/plugins/houdini/load/load_alembic.py
@@ -42,8 +42,10 @@ class AbcLoader(api.Loader):
         container = obj.createNode("geo", node_name=node_name)
 
         # Remove the file node, it only loads static meshes
-        file_node = container.node("file1".format(node_name))
-        file_node.destroy()
+        # Houdini 17 has removed the file node from the geo node
+        file_node = container.node("file1")
+        if file_node:
+            file_node.destroy()
 
         # Create an alembic node (supports animation)
         alembic = container.createNode("alembic", node_name=node_name)


### PR DESCRIPTION
This resolved internal issue of PLN-179

In Houdini 17 the file node no longer exists when creating a `geo` node in object level. Added backwards compatibility for Houdini 16.x 