### PR TITLE
Add attribute control for point cache

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_pointcache.py
+++ b/colorbleed/plugins/maya/create/colorbleed_pointcache.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import avalon.maya
 from colorbleed.maya import lib
 
@@ -15,22 +13,14 @@ class CreatePointCache(avalon.maya.Creator):
     def __init__(self, *args, **kwargs):
         super(CreatePointCache, self).__init__(*args, **kwargs)
 
-        # create an ordered dict with the existing data first
-        data = OrderedDict(**self.data)
+        data = {"writeColorSets": False,  # Vertex colors with the geometry.
+                "renderableOnly": False,  # Only renderable visible shapes
+                "visibleOnly": False,  # only nodes that are visible
+                "attr": "cbId",  # Add options for custom attributes
+                "attrPrefix": ""}
 
         # get basic animation data : start / end / handles / steps
         for key, value in lib.collect_animation_data().items():
             data[key] = value
 
-        # Write vertex colors with the geometry.
-        data["writeColorSets"] = False
-
-        # Include only renderable visible shapes.
-        # Skips locators and empty transforms
-        data["renderableOnly"] = False
-
-        # Include only nodes that are visible at least once during the
-        # frame range.
-        data["visibleOnly"] = False
-
-        self.data = data
+        self.data.update(data)

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -32,6 +32,12 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
             start -= handles
             end += handles
 
+        attrs = instance.data.get("attr", "").split(";")
+        if not attrs:
+            attrs = ["cbId"]
+
+        attr_prefixes = instance.data.get("attrPrefix", "").split(";")
+
         # Get extra export arguments
         writeColorSets = instance.data.get("writeColorSets", False)
 
@@ -44,7 +50,8 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
 
         options = {
             "step": instance.data.get("step", 1.0),
-            "attr": ["cbId"],
+            "attr": attrs,
+            "attrPrefix": attr_prefixes,
             "writeVisibility": True,
             "writeCreases": True,
             "writeColorSets": writeColorSets,


### PR DESCRIPTION
Fix internal issue: PLN-80

This PR will give the user extra control on which attribute(s) are exported along when writing a point cache. This will ensure that control attributes for shaders or FX are consistent during production.

* Improved creator plugin
* Fetch controls from instance for export