### PR TITLE
Patch for breaking validator

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_vrayscene.py
+++ b/colorbleed/plugins/maya/create/colorbleed_vrayscene.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import avalon.maya
 
 
@@ -12,27 +10,16 @@ class CreateVRayScene(avalon.maya.Creator):
     def __init__(self, *args, **kwargs):
         super(CreateVRayScene, self).__init__(*args, **kwargs)
 
-        # We won't be publishing this one
-        self.data["id"] = "avalon.vrayscene"
-
         # We don't need subset or asset attributes
         self.data.pop("subset", None)
         self.data.pop("asset", None)
 
-        data = OrderedDict(**self.data)
-
-        data["camera"] = self._get_cameras()
-        data["suspendRenderJob"] = False
-        data["suspendPublishJob"] = False
-        data["extendFrames"] = False
-        data["pools"] = ""
-
-        self.data = data
+        self.data.update({
+            "id": "avalon.vrayscene",  # We won't be publishing this one
+            "suspendRenderJob": False,
+            "suspendPublishJob": False,
+            "extendFrames": False,
+            "pools": ""
+        })
 
         self.options = {"useSelection": False}  # Force no content
-
-    def _get_cameras(self):
-        from maya import cmds
-
-        return [c for c in cmds.ls(type="camera")
-                if cmds.getAttr("%s.renderable" % c)]

--- a/colorbleed/plugins/maya/create/colorbleed_vrayscene.py
+++ b/colorbleed/plugins/maya/create/colorbleed_vrayscene.py
@@ -13,6 +13,7 @@ class CreateVRayScene(avalon.maya.Creator):
         # We don't need subset or asset attributes
         self.data.pop("subset", None)
         self.data.pop("asset", None)
+        self.data.pop("active", None)
 
         self.data.update({
             "id": "avalon.vrayscene",  # We won't be publishing this one

--- a/colorbleed/plugins/maya/publish/collect_renderable_camera.py
+++ b/colorbleed/plugins/maya/publish/collect_renderable_camera.py
@@ -8,7 +8,7 @@ from colorbleed.maya import lib
 class CollectRenderableCamera(pyblish.api.InstancePlugin):
     """Collect the renderable camera(s) for the render layer"""
 
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder + 0.01
     label = "Collect Renderable Camera(s)"
     hosts = ["maya"]
     families = ["colorbleed.vrayscene",
@@ -21,4 +21,7 @@ class CollectRenderableCamera(pyblish.api.InstancePlugin):
         with lib.renderlayer(layer):
             renderable = [c for c in cameras if
                           cmds.getAttr("%s.renderable" % c)]
-            instance.data.update({"camera": renderable})
+
+        self.log.info("Found cameras %s" % len(renderable))
+
+        instance.data.update({"cameras": renderable})

--- a/colorbleed/plugins/maya/publish/collect_renderable_camera.py
+++ b/colorbleed/plugins/maya/publish/collect_renderable_camera.py
@@ -1,0 +1,24 @@
+import pyblish.api
+
+from maya import cmds
+
+from colorbleed.maya import lib
+
+
+class CollectRenderableCamera(pyblish.api.InstancePlugin):
+    """Collect the renderable camera(s) for the render layer"""
+
+    order = pyblish.api.CollectorOrder
+    label = "Collect Renderable Camera(s)"
+    hosts = ["maya"]
+    families = ["colorbleed.vrayscene",
+                "colorbleed.renderlayer"]
+
+    def process(self, instance):
+        layer = instance.data["setMembers"]
+
+        cameras = cmds.ls(type="camera", long=True)
+        with lib.renderlayer(layer):
+            renderable = [c for c in cameras if
+                          cmds.getAttr("%s.renderable" % c)]
+            instance.data.update({"camera": renderable})

--- a/colorbleed/plugins/maya/publish/collect_vray_scene.py
+++ b/colorbleed/plugins/maya/publish/collect_vray_scene.py
@@ -104,5 +104,4 @@ class CollectVRayScene(pyblish.api.ContextPlugin):
 
             instance = context.create_instance(layer)
             self.log.info("Created: %s" % instance.name)
-            self.log.debug("VRay Data: %s" % vrscene_data)
             instance.data.update(data)

--- a/colorbleed/plugins/maya/publish/submit_vray_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_vray_deadline.py
@@ -191,8 +191,11 @@ class VraySubmitDeadline(pyblish.api.InstancePlugin):
         cmd = ('-r vray -proj {project} -cam {cam} -noRender -s {startFrame} '
                '-e {endFrame} -rl {layer} -exportFramesSeparate')
 
+        # Get the camera
+        cammera = instance.data["cameras"][0]
+
         return cmd.format(project=instance.context.data["workspaceDir"],
-                          cam=instance.data.get("camera", "persp"),
+                          cam=cammera,
                           startFrame=instance.data["startFrame"],
                           endFrame=instance.data["endFrame"],
                           layer=instance.name)

--- a/colorbleed/plugins/maya/publish/submit_vray_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_vray_deadline.py
@@ -130,7 +130,7 @@ class VraySubmitDeadline(pyblish.api.InstancePlugin):
         instance.data["outputDir"] = render_ouput
 
         # Format output file name
-        sequence_filename = ".".join([instance.name, "%04d", ext])
+        sequence_filename = ".".join([instance.name, ext])
         output_filename = os.path.join(render_ouput, sequence_filename)
 
         payload_b = {

--- a/colorbleed/plugins/maya/publish/submit_vray_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_vray_deadline.py
@@ -183,6 +183,9 @@ class VraySubmitDeadline(pyblish.api.InstancePlugin):
     def build_command(self, instance):
         """Create command for Render.exe to export vray scene
 
+        Args:
+            instance
+
         Returns:
             str
 
@@ -202,6 +205,9 @@ class VraySubmitDeadline(pyblish.api.InstancePlugin):
 
     def build_jobinfo_environment(self, env):
         """Format environment keys and values to match Deadline rquirements
+
+        Args:
+            env(dict): environment dictionary
 
         Returns:
             dict

--- a/colorbleed/plugins/maya/publish/validate_render_single_camera.py
+++ b/colorbleed/plugins/maya/publish/validate_render_single_camera.py
@@ -1,9 +1,6 @@
-from maya import cmds
-
 import pyblish.api
 import colorbleed.api
 import colorbleed.maya.action
-import colorbleed.maya.lib as lib
 
 
 class ValidateRenderSingleCamera(pyblish.api.InstancePlugin):
@@ -18,33 +15,15 @@ class ValidateRenderSingleCamera(pyblish.api.InstancePlugin):
     """
 
     order = colorbleed.api.ValidateContentsOrder
+    label = "Render Single Camera"
     hosts = ['maya']
     families = ['colorbleed.renderlayer',
                 "colorbleed.vrayscene"]
-    label = "Render Single Camera"
+
     actions = [colorbleed.maya.action.SelectInvalidAction]
-
-    @staticmethod
-    def get_invalid(instance):
-
-        layer = instance.data["setMembers"]
-
-        cameras = cmds.ls(type='camera', long=True)
-
-        with lib.renderlayer(layer):
-            renderable = [cam for cam in cameras if
-                          cmds.getAttr(cam + ".renderable")]
-
-            if len(renderable) == 0:
-                raise RuntimeError("No renderable cameras found.")
-            elif len(renderable) > 1:
-                return renderable
-            else:
-                return []
 
     def process(self, instance):
         """Process all the cameras in the instance"""
-        invalid = self.get_invalid(instance)
-        if invalid:
-            raise RuntimeError("Multiple renderable cameras"
-                               "found: {0}".format(invalid))
+        cameras = instance.data.get("camera", [])
+        assert len(cameras) == 1, ("Multiple renderable cameras" "found: %s " %
+                                   instance.data["setMembers"])

--- a/colorbleed/plugins/maya/publish/validate_render_single_camera.py
+++ b/colorbleed/plugins/maya/publish/validate_render_single_camera.py
@@ -20,10 +20,14 @@ class ValidateRenderSingleCamera(pyblish.api.InstancePlugin):
     families = ['colorbleed.renderlayer',
                 "colorbleed.vrayscene"]
 
-    actions = [colorbleed.maya.action.SelectInvalidAction]
-
     def process(self, instance):
         """Process all the cameras in the instance"""
-        cameras = instance.data.get("camera", [])
-        assert len(cameras) == 1, ("Multiple renderable cameras" "found: %s " %
-                                   instance.data["setMembers"])
+
+    @classmethod
+    def get_invalid(cls, instance):
+        cameras = instance.data.get("cameras", [])
+        if len(cameras) != 1:
+            cls.log.error("Multiple renderable cameras" "found: %s " %
+                          instance.data["setMembers"])
+
+            return [instance.data["setMembers"]]

--- a/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
@@ -14,6 +14,8 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
     def process(self, context):
 
         # Check if there are any vray scene instances
+        # The reason to not use host.lsattr() as used in collect_vray_scene
+        # is because that information is already available in the context
         vrayscene_instances = []
         for inst in context[:]:
             if inst.data["family"] in self.families:

--- a/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
@@ -13,6 +13,20 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
+        # Check if there are any vray scene instances
+        vrayscene_instances = []
+        for inst in context[:]:
+            if inst.data["family"] in self.families:
+                # Skip if instances is inactive
+                if not inst.data["active"]:
+                    continue
+
+                vrayscene_instances.append(inst)
+
+        if not vrayscene_instances:
+            self.log.info("No VRay Scene instances found, skipping..")
+            return
+
         # Get vraySettings node
         vray_settings = cmds.ls(type="VRaySettingsNode")
         assert vray_settings, "Please ensure a VRay Settings Node is present"

--- a/colorbleed/plugins/maya/publish/validate_yeti_renderscript_callbacks.py
+++ b/colorbleed/plugins/maya/publish/validate_yeti_renderscript_callbacks.py
@@ -56,8 +56,11 @@ class ValidateYetiRenderScriptCallbacks(pyblish.api.InstancePlugin):
                             % renderer)
             return False
 
-        pre_render_callback = cmds.getAttr("defaultRenderGlobals.preMel")
-        post_render_callback = cmds.getAttr("defaultRenderGlobals.postMel")
+        pre_mel_attr = "defaultRenderGlobals.preMel"
+        post_mel_attr = "defaultRenderGlobals.postMel"
+
+        pre_render_callback = cmds.getAttr(pre_mel_attr) or ""
+        post_render_callback = cmds.getAttr(post_mel_attr) or ""
 
         pre_callbacks = pre_render_callback.split(";")
         post_callbacks = post_render_callback.split(";")


### PR DESCRIPTION
Updated the logic to validate the VRay translator settings. 

1. There is bug in pyblish ( fix is ready [here](https://github.com/pyblish/pyblish-base/pull/325) and [here](https://github.com/pyblish/pyblish-qml/pull/266) ) which allows all context plugins to ignore the `family`. Because of this the `validate_vray_translator_settings` plugin was being triggered even when having no related instance / family.

2. There was an issue with the output name from the VRay Standalone renderer. The output file name for the JobInfo previously `<layername>.%04d.<ext>` but the output generated was `<layername>.%04d.<frame>.<ext>`. I have not been able to get find the documentation about this but I am assuming the render settings for the about are baked in the `vrscene` file. There for I have removed the `%04d` from the output file name.

3. I added the a new collector which benefits both render and vray scene exporting. It will collect the renderable cameras for each renderlayer, this makes the validator for renderable cameras simpler.