### PR TITLE
Fixed validator

### DIFF
--- a/colorbleed/action.py
+++ b/colorbleed/action.py
@@ -87,6 +87,6 @@ class RepairContextAction(pyblish.api.Action):
         # Apply pyblish.logic to get the instances for the plug-in
         if plugin in errored_plugins:
             self.log.info("Attempting fix ...")
-            plugin.repair()
+            plugin.repair(context)
 
 

--- a/colorbleed/plugins/maya/publish/validate_maya_units.py
+++ b/colorbleed/plugins/maya/publish/validate_maya_units.py
@@ -36,7 +36,7 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin):
         assert fps and fps == asset_fps, "Scene must be %s FPS" % asset_fps
 
     @classmethod
-    def repair(cls):
+    def repair(cls, context):
         """Fix the current FPS setting of the scene, set to PAL(25.0 fps)"""
 
         cls.log.info("Setting angular unit to 'degrees'")

--- a/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
@@ -16,14 +16,8 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
         # Check if there are any vray scene instances
         # The reason to not use host.lsattr() as used in collect_vray_scene
         # is because that information is already available in the context
-        vrayscene_instances = []
-        for inst in context[:]:
-            if inst.data["family"] in self.families:
-                # Skip if instances is inactive
-                if not inst.data["active"]:
-                    continue
-
-                vrayscene_instances.append(inst)
+        vrayscene_instances = [i for i in context[:] if i.data["family"]
+                               in self.families]
 
         if not vrayscene_instances:
             self.log.info("No VRay Scene instances found, skipping..")

--- a/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
@@ -13,14 +13,23 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
+        invalid = self.get_invalid(context)
+        if invalid:
+            raise RuntimeError("Found invalid VRay Translator settings!")
+
+    @classmethod
+    def get_invalid(cls, context):
+
+        invalid = False
+
         # Check if there are any vray scene instances
         # The reason to not use host.lsattr() as used in collect_vray_scene
         # is because that information is already available in the context
         vrayscene_instances = [i for i in context[:] if i.data["family"]
-                               in self.families]
+                               in cls.families]
 
         if not vrayscene_instances:
-            self.log.info("No VRay Scene instances found, skipping..")
+            cls.log.info("No VRay Scene instances found, skipping..")
             return
 
         # Get vraySettings node

--- a/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
@@ -53,8 +53,8 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
 
         return invalid
 
-    @staticmethod
-    def repair():
+    @classmethod
+    def repair(cls, context):
 
         vray_settings = cmds.ls(type="VRaySettingsNode")
         if not vray_settings:

--- a/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_translator_settings.py
@@ -39,17 +39,22 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
         node = vray_settings[0]
 
         if not cmds.getAttr("{}.vrscene_on".format(node)):
-            self.info.error("Export vrscene not enabled")
+            cls.log.error("Export vrscene not enabled")
+            invalid = True
 
         if not cmds.getAttr("{}.misc_eachFrameInFile".format(node)):
-            self.info.error("Each Frame in File not enabled")
+            cls.log.error("Each Frame in File not enabled")
+            invalid = True
 
         vrscene_filename = cmds.getAttr("{}.vrscene_filename".format(node))
         if vrscene_filename != "vrayscene/<Scene>/<Scene>_<Layer>/<Layer>":
-            self.info.error("Template for file name is wrong")
+            cls.log.error("Template for file name is wrong")
+            invalid = True
 
-    @classmethod
-    def repair(cls, context):
+        return invalid
+
+    @staticmethod
+    def repair():
 
         vray_settings = cmds.ls(type="VRaySettingsNode")
         if not vray_settings:


### PR DESCRIPTION
_Resolves internal issue PLN-189_

Synchronized validator with the instance to ensure the validator does not fail on missing keys in the instance data.

For consistency I have added a `get_invalid` method similar to instance validators. The repair function can now be called without error. It needed to have a static method decorator instead of class method to ensure it could be triggered by the Repair Context Action.

All logging messages are now correctly called and visible in Pyblish.
