### PR TITLE
Fix published textures sometimes not being remapped correctly (LKD-17)

### DIFF
--- a/colorbleed/plugins/maya/publish/extract_look.py
+++ b/colorbleed/plugins/maya/publish/extract_look.py
@@ -1,5 +1,7 @@
 import os
 import json
+import tempfile
+import contextlib
 from collections import OrderedDict
 
 from maya import cmds
@@ -9,6 +11,38 @@ import avalon.maya
 
 import colorbleed.api
 import colorbleed.maya.lib as lib
+
+
+@contextlib.contextmanager
+def no_workspace_dir():
+    """Force maya to a fake temporary workspace directory.
+
+    Note: This is not maya.cmds.workspace 'rootDirectory' but the 'directory'
+
+    This helps to avoid Maya automatically remapping image paths to files
+    relative to the currently set directory.
+
+    """
+
+    # Store current workspace
+    original = cmds.workspace(query=True, directory=True)
+
+    # Set a fake workspace
+    fake_workspace_dir = tempfile.mkdtemp()
+    cmds.workspace(directory=fake_workspace_dir)
+
+    try:
+        yield
+    finally:
+        try:
+            cmds.workspace(directory=original)
+        except RuntimeError:
+            # If the original workspace directory didn't exist either
+            # ignore the fact that it fails to reset it to the old path
+            pass
+
+        # Remove the temporary directory
+        os.rmdir(fake_workspace_dir)
 
 
 class ExtractLook(colorbleed.api.Extractor):
@@ -65,18 +99,23 @@ class ExtractLook(colorbleed.api.Extractor):
         with lib.renderlayer(layer):
             # TODO: Ensure membership edits don't become renderlayer overrides
             with lib.empty_sets(sets, force=True):
-                with lib.attribute_values(remap):
-                    with avalon.maya.maintained_selection():
-                        cmds.select(sets, noExpand=True)
-                        cmds.file(maya_path,
-                                  force=True,
-                                  typ="mayaAscii",
-                                  exportSelected=True,
-                                  preserveReferences=False,
-                                  channels=True,
-                                  constraints=True,
-                                  expressions=True,
-                                  constructionHistory=True)
+                # To avoid Maya trying to automatically remap the file
+                # textures relative to the `workspace -directory` we force
+                # it to a fake temporary workspace. This fixes textures
+                # getting incorrectly remapped. (LKD-17, PLN-101)
+                with no_workspace_dir():
+                    with lib.attribute_values(remap):
+                        with avalon.maya.maintained_selection():
+                            cmds.select(sets, noExpand=True)
+                            cmds.file(maya_path,
+                                      force=True,
+                                      typ="mayaAscii",
+                                      exportSelected=True,
+                                      preserveReferences=False,
+                                      channels=True,
+                                      constraints=True,
+                                      expressions=True,
+                                      constructionHistory=True)
 
         # Write the JSON data
         self.log.info("Extract json..")


### PR DESCRIPTION
This fixes issue LKD-17 and PLN-101 where sometimes texture paths were not remapped correctly after publishing a look.

This was a beast to track down why it was happening and was actually a longstanding issue. Finally resolved!

I was unable to set the workspace temporarily to a non-existing directory, so I chose to set it briefly to a "temporary directory".