### PR TITLE
Collect machine name

### DIFF
--- a/colorbleed/plugins/global/publish/collect_machine_name.py
+++ b/colorbleed/plugins/global/publish/collect_machine_name.py
@@ -1,0 +1,14 @@
+import pyblish.api
+
+
+class CollectMachineName(pyblish.api.ContextPlugin):
+    label = "Local Machine Name"
+    order = pyblish.api.CollectorOrder
+    hosts = ["*"]
+
+    def process(self, context):
+        import socket
+
+        machine_name = socket.gethostname()
+        self.log.info("Machine name: %s" % machine_name)
+        context.data.update({"machine": machine_name})

--- a/colorbleed/plugins/global/publish/integrate.py
+++ b/colorbleed/plugins/global/publish/integrate.py
@@ -340,7 +340,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                         "time": context.data["time"],
                         "author": context.data["user"],
                         "source": source,
-                        "comment": context.data.get("comment")}
+                        "comment": context.data.get("comment"),
+                        "machine": context.data.get("machine")}
 
         # Include optional data if present in
         optionals = ["startFrame", "endFrame", "step", "handles"]


### PR DESCRIPTION
Resolves internal issue PLN-170

Aside of Author or User include the Machine name that generated the publish. This helps debugging any specific machine issues, e.g. machine X created a wrong publish.

It will also currently help in showing who actually generated it since the user accounts on the workstations currently only list "Guest" or alike. :)