### PR TITLE
Collect FPS from work scene

### DIFF
--- a/colorbleed/plugins/global/publish/integrate.py
+++ b/colorbleed/plugins/global/publish/integrate.py
@@ -341,7 +341,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                         "author": context.data["user"],
                         "source": source,
                         "comment": context.data.get("comment"),
-                        "machine": context.data.get("machine")}
+                        "machine": context.data.get("machine"),
+                        "fps": context.data.get("fps")}
 
         # Include optional data if present in
         optionals = ["startFrame", "endFrame", "step", "handles"]

--- a/colorbleed/plugins/houdini/publish/collect_workscene_fps.py
+++ b/colorbleed/plugins/houdini/publish/collect_workscene_fps.py
@@ -1,0 +1,15 @@
+import pyblish.api
+import hou
+
+
+class CollectWorksceneFPS(pyblish.api.ContextPlugin):
+    """Get the FPS of the work scene"""
+
+    label = "Workscene FPS"
+    order = pyblish.api.CollectorOrder
+    hosts = ["houdini"]
+
+    def process(self, context):
+        fps = hou.fps()
+        self.log.info("Workscene FPS: %s" % fps)
+        context.data.update({"fps": fps})

--- a/colorbleed/plugins/maya/publish/collect_workscene_fps.py
+++ b/colorbleed/plugins/maya/publish/collect_workscene_fps.py
@@ -1,0 +1,15 @@
+import pyblish.api
+from maya import mel
+
+
+class CollectWorksceneFPS(pyblish.api.ContextPlugin):
+    """Get the FPS of the work scene"""
+
+    label = "Workscene FPS"
+    order = pyblish.api.CollectorOrder
+    hosts = ["maya"]
+
+    def process(self, context):
+        fps = mel.eval('currentTimeUnitToFPS()')
+        self.log.info("Workscene FPS: %s" % fps)
+        context.data.update({"fps": fps})


### PR DESCRIPTION
Resolves internal isse PLN-156

Publish along the FPS of the content (the units in the work scene) and make it visible in the loader.