### PR TITLE
Add FPS check to Houdini pipeline

### DIFF
--- a/colorbleed/houdini/__init__.py
+++ b/colorbleed/houdini/__init__.py
@@ -35,10 +35,9 @@ def install():
 
     log.info("Installing callbacks ... ")
     avalon.on("init", on_init)
+    avalon.before("save", before_save)
     avalon.on("save", on_save)
     avalon.on("open", on_open)
-
-    log.info("Overriding existing event 'taskChanged'")
 
     log.info("Setting default family states for loader..")
     avalon.data["familiesStateToggled"] = ["colorbleed.imagesequence"]
@@ -46,6 +45,10 @@ def install():
 
 def on_init(*args):
     houdini.on_houdini_initialize()
+
+
+def before_save(*args):
+    return lib.validate_fps()
 
 
 def on_save(*args):
@@ -72,7 +75,6 @@ def on_open(*args):
 
         # Get main window
         parent = hou.ui.mainQtWindow()
-
         if parent is None:
             log.info("Skipping outdated content pop-up "
                      "because Maya window can't be found.")

--- a/colorbleed/houdini/lib.py
+++ b/colorbleed/houdini/lib.py
@@ -4,15 +4,17 @@ from contextlib import contextmanager
 
 import hou
 
+from colorbleed import lib
+
 from avalon import api, io
-from avalon.houdini import lib
+from avalon.houdini import lib as houdini
 
 
 def set_id(node, unique_id, overwrite=False):
 
     exists = node.parm("id")
     if not exists:
-        lib.imprint(node, {"id": unique_id})
+        houdini.imprint(node, {"id": unique_id})
 
     if not exists and overwrite:
         node.setParm("id", unique_id)
@@ -188,3 +190,45 @@ def attribute_values(node, data):
         pass
     finally:
         node.setParms(previous_attrs)
+
+
+def set_scene_fps(fps):
+    hou.setFps(fps)
+
+
+# Valid FPS
+def validate_fps():
+    """Validate current scene FPS and show pop-up when it is incorrect
+
+    Returns:
+        bool
+
+    """
+
+    fps = lib.get_asset_fps()
+    current_fps = hou.fps()  # returns float
+
+    if current_fps != fps:
+
+        from ..widgets import popup
+
+        # Find main window
+        parent = hou.ui.mainQtWindow()
+        if parent is None:
+            pass
+        else:
+            dialog = popup.Popup2(parent=parent)
+            dialog.setModal(True)
+            dialog.setWindowTitle("Maya scene not in line with project")
+            dialog.setMessage("The FPS is out of sync, please fix")
+
+            # Set new text for button (add optional argument for the popup?)
+            toggle = dialog.widgets["toggle"]
+            toggle.setEnabled(False)
+            dialog.on_show.connect(lambda: set_scene_fps(fps))
+
+            dialog.show()
+
+            return False
+
+    return True

--- a/colorbleed/plugins/global/publish/integrate.py
+++ b/colorbleed/plugins/global/publish/integrate.py
@@ -341,7 +341,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                         "author": context.data["user"],
                         "source": source,
                         "comment": context.data.get("comment"),
-                        "machine": context.data.get("machine")}
+                        "machine": context.data.get("machine"),
+                        "fps": context.data.get("fps")}
 
         # Include optional data if present in
         optionals = ["startFrame", "endFrame", "step", "handles"]

--- a/colorbleed/plugins/houdini/publish/collect_workscene_fps.py
+++ b/colorbleed/plugins/houdini/publish/collect_workscene_fps.py
@@ -1,0 +1,15 @@
+import pyblish.api
+import hou
+
+
+class CollectWorksceneFPS(pyblish.api.ContextPlugin):
+    """Get the FPS of the work scene"""
+
+    label = "Workscene FPS"
+    order = pyblish.api.CollectorOrder
+    hosts = ["houdini"]
+
+    def process(self, context):
+        fps = hou.fps()
+        self.log.info("Workscene FPS: %s" % fps)
+        context.data.update({"fps": fps})

--- a/colorbleed/plugins/maya/publish/collect_workscene_fps.py
+++ b/colorbleed/plugins/maya/publish/collect_workscene_fps.py
@@ -1,0 +1,15 @@
+import pyblish.api
+from maya import mel
+
+
+class CollectWorksceneFPS(pyblish.api.ContextPlugin):
+    """Get the FPS of the work scene"""
+
+    label = "Workscene FPS"
+    order = pyblish.api.CollectorOrder
+    hosts = ["maya"]
+
+    def process(self, context):
+        fps = mel.eval('currentTimeUnitToFPS()')
+        self.log.info("Workscene FPS: %s" % fps)
+        context.data.update({"fps": fps})


### PR DESCRIPTION
Adds FPS collectors for Houdini and Maya.

In order to have consistency across all DCCs I have added the `validate_fps` to the `before_save` callback of Houdini to ensure the project saved is the same setting as the project.
