### PR TITLE
Exclude parent hierarchy by default for pointcaches

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_animation.py
+++ b/colorbleed/plugins/maya/create/colorbleed_animation.py
@@ -29,3 +29,6 @@ class CreateAnimation(avalon.maya.Creator):
         # Include only nodes that are visible at least once during the
         # frame range.
         self.data["visibleOnly"] = False
+
+        # Include the groups above the out_SET content
+        self.data["includeParentHierarchy"] = False  # Include parent groups

--- a/colorbleed/plugins/maya/create/colorbleed_model.py
+++ b/colorbleed/plugins/maya/create/colorbleed_model.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import avalon.maya
 
 
@@ -14,8 +12,12 @@ class CreateModel(avalon.maya.Creator):
     def __init__(self, *args, **kwargs):
         super(CreateModel, self).__init__(*args, **kwargs)
 
-        data = {"writeColorSets": False,  # Vertex colors with the geometry.
-                "attr": "",  # Add options for custom attributes
-                "attrPrefix": ""}
+        # Vertex colors with the geometry
+        self.data["writeColorSets"] = False
 
-        self.data.update(data)
+        # Include attributes by attribute name or prefix
+        self.data["attr"] = ""
+        self.data["attrPrefix"] = ""
+
+        # Whether to include parent hierarchy of nodes in the instance
+        self.data["includeParentHierarchy"] = False

--- a/colorbleed/plugins/maya/create/colorbleed_pointcache.py
+++ b/colorbleed/plugins/maya/create/colorbleed_pointcache.py
@@ -19,6 +19,7 @@ class CreatePointCache(avalon.maya.Creator):
         self.data["writeColorSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible
+        self.data["includeParentHierarchy"] = False  # Include parent groups
 
         # Add options for custom attributes
         self.data["attr"] = ""

--- a/colorbleed/plugins/maya/publish/collect_instances.py
+++ b/colorbleed/plugins/maya/publish/collect_instances.py
@@ -99,7 +99,11 @@ class CollectInstances(pyblish.api.ContextPlugin):
                                           fullPath=True) or []
             children = cmds.ls(children, noIntermediate=True, long=True)
 
-            parents = self.get_all_parents(members)
+            parents = []
+            if data.get("includeParentHierarchy", True):
+                # If `includeParentHierarchy` then include the parents
+                # so they will also be picked up in the instance by validators
+                parents = self.get_all_parents(members)
             members_hierarchy = list(set(members + children + parents))
 
             # Create the instance

--- a/colorbleed/plugins/maya/publish/extract_animation.py
+++ b/colorbleed/plugins/maya/publish/extract_animation.py
@@ -27,12 +27,12 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
             raise RuntimeError("Couldn't find exactly one out_SET: "
                                "{0}".format(out_sets))
         out_set = out_sets[0]
-        nodes = cmds.sets(out_set, query=True)
+        roots = cmds.sets(out_set, query=True)
 
         # Include all descendants
-        nodes += cmds.listRelatives(nodes,
-                                    allDescendents=True,
-                                    fullPath=True) or []
+        nodes = roots + cmds.listRelatives(roots,
+                                           allDescendents=True,
+                                           fullPath=True) or []
 
         # Collect the start and end including handles
         start = instance.data["startFrame"]
@@ -57,6 +57,12 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
             "uvWrite": True,
             "selection": True
         }
+
+        if not instance.data.get("includeParentHierarchy", True):
+            # Set the root nodes if we don't want to include parents
+            # The roots are to be considered the ones that are the actual
+            # direct members of the set
+            options["root"] = roots
 
         if int(cmds.about(version=True)) >= 2017:
             # Since Maya 2017 alembic supports multiple uv sets - write them.

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -7,34 +7,6 @@ import colorbleed.api
 from colorbleed.maya.lib import extract_alembic
 
 
-def iter_parents(node):
-    n = node.count("|")
-    for i in range(1, n):
-        yield node.rsplit("|", i)[0]
-
-
-def get_highest_in_hierarchy(nodes):
-    """Return the highest in the hierachies from nodes
-
-    This will return each highest node in separate hierarchies.
-    E.g.
-        get_highest_in_hierarchy(["|A|B|C", "A|B", "D|E"])
-        # ["A|B", "D|E"]
-
-    """
-    # Ensure we use long names
-    nodes = cmds.ls(nodes, long=True)
-    lookup = set(nodes)
-    highest = []
-    for node in nodes:
-        # If no parents are within the original list
-        # then this is a highest node
-        if not any(n in lookup for n in iter_parents(node)):
-            highest.append(node)
-
-    return highest
-
-
 class ExtractColorbleedAlembic(colorbleed.api.Extractor):
     """Produce an alembic of just point positions and normals.
 

--- a/colorbleed/plugins/maya/publish/validate_model_content.py
+++ b/colorbleed/plugins/maya/publish/validate_model_content.py
@@ -63,7 +63,8 @@ class ValidateModelContent(pyblish.api.InstancePlugin):
             cls.log.error("Must have exactly one top group")
             if len(assemblies) == 0:
                 cls.log.warning("No top group found. "
-                                "(Are there objects in the instance?)")
+                                "(Are there objects in the instance?"
+                                " Or is it parented in another group?)")
             return assemblies or True
 
         def _is_visible(node):


### PR DESCRIPTION
By default exclude parent hierarchy for pointcaches (internal issue PLN-205)
This adds in a toggle to export alembics without the parent hierarchy