### PR TITLE
Suspend viewport during camera extraction (optimization)

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -372,26 +372,6 @@ def evaluation(mode="off"):
 
 
 @contextlib.contextmanager
-def no_refresh():
-    """Temporarily disables Maya's UI updates
-
-    Note:
-        This only disabled the main pane and will sometimes still
-        trigger updates in torn off panels.
-
-    """
-
-    pane = _get_mel_global('gMainPane')
-    state = cmds.paneLayout(pane, query=True, manage=True)
-    cmds.paneLayout(pane, edit=True, manage=False)
-
-    try:
-        yield
-    finally:
-        cmds.paneLayout(pane, edit=True, manage=state)
-
-
-@contextlib.contextmanager
 def empty_sets(sets, force=False):
     """Remove all members of the sets during the context"""
 

--- a/colorbleed/plugins/maya/publish/collect_instances.py
+++ b/colorbleed/plugins/maya/publish/collect_instances.py
@@ -12,29 +12,14 @@ class CollectInstances(pyblish.api.ContextPlugin):
     Identifier:
         id (str): "pyblish.avalon.instance"
 
-    Supported Families:
-        avalon.model: Geometric representation of artwork
-        avalon.rig: An articulated model for animators.
-            A rig may contain a series of sets in which to identify
-            its contents.
-
-            - cache_SEL: Should contain cachable polygonal meshes
-            - controls_SEL: Should contain animatable controllers for animators
-            - resources_SEL: Should contain nodes that reference external files
-
-            Limitations:
-                - Only Maya is supported
-                - One (1) rig per scene file
-                - Unmanaged history, it is up to the TD to ensure
-                    history is up to par.
-        avalon.animation: Pointcache of `avalon.rig`
-
     Limitations:
         - Does not take into account nodes connected to those
             within an objectSet. Extractors are assumed to export
             with history preserved, but this limits what they will
             be able to achieve and the amount of data available
-            to validators.
+            to validators. An additional collector could also
+            append this input data into the instance, as we do
+            for `colorbleed.rig` with collect_history.
 
     """
 

--- a/colorbleed/plugins/maya/publish/extract_camera_alembic.py
+++ b/colorbleed/plugins/maya/publish/extract_camera_alembic.py
@@ -67,7 +67,7 @@ class ExtractCameraAlembic(colorbleed.api.Extractor):
             job_str += ' -file "{0}"'.format(path)
 
             with lib.evaluation("off"):
-                with lib.no_refresh():
+                with avalon.maya.suspended_refresh():
                     cmds.AbcExport(j=job_str, verbose=False)
 
         if "files" not in instance.data:

--- a/colorbleed/plugins/maya/publish/extract_camera_mayaAscii.py
+++ b/colorbleed/plugins/maya/publish/extract_camera_mayaAscii.py
@@ -127,7 +127,7 @@ class ExtractCameraMayaAscii(colorbleed.api.Extractor):
         self.log.info("Performing camera bakes for: {0}".format(transform))
         with avalon.maya.maintained_selection():
             with lib.evaluation("off"):
-                with lib.no_refresh():
+                with avalon.maya.suspended_refresh():
                     baked = lib.bake_to_world_space(
                         transform,
                         frame_range=range_with_handles,


### PR DESCRIPTION
This increases the speed of camera exports as it really suspends the viewport refreshing (also for torn off panels). This fixes internal issue PLN-202.