### PR TITLE
Support Yeti multiple image search paths (split by os.path.pathsep)

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -128,11 +128,11 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
             files = []
             if os.path.isabs(texture):
                 self.log.debug("Texture is absolute path, ignoring "
-                               "image search paths.. %s" % texture)
+                               "image search paths for: %s" % texture)
                 files = self.search_textures(texture)
             else:
                 for root in image_search_paths:
-                    filepath = os.path.join(root, image_search_paths)
+                    filepath = os.path.join(root, texture)
                     files = self.search_textures(filepath)
                     if files:
                         # Break out on first match in search paths..

--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -234,7 +234,7 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
 
         return []
 
-    def get_sequence(self, filename, pattern="%04d"):
+    def get_sequence(self, filepath, pattern="%04d"):
         """Get sequence from filename.
 
         This will only return files if they exist on disk as it tries
@@ -245,7 +245,7 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
         0000, 0001.
 
         Arguments:
-            filename (str): The full path to filename containing the given
+            filepath (str): The full path to filename containing the given
             pattern.
             pattern (str): The pattern to swap with the variable frame number.
 
@@ -255,10 +255,10 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
         """
         from avalon.vendor import clique
 
-        escaped = re.escape(filename)
+        escaped = re.escape(filepath)
         re_pattern = escaped.replace(pattern, "-?[0-9]+")
 
-        source_dir = os.path.dirname(filename)
+        source_dir = os.path.dirname(filepath)
         files = [f for f in os.listdir(source_dir)
                  if re.match(re_pattern, f)]
 

--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -169,25 +169,27 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
                                         param="reference_file",
                                         getParamValue=True)
 
-            if not os.path.isfile(ref_file):
-                self.log.warning("Reference node '%s' has no valid file "
-                                 "path set: %s" % (reference_node, ref_file))
-                # TODO: This should allow to pass and fail in Validator instead
-                raise RuntimeError("Reference file must be a full file path!")
-
             # Create resource dict
-            item = {"files": [],
-                    "source": ref_file,
-                    "node": node,
-                    "graphnode": reference_node,
-                    "param": "reference_file"}
+            item = {
+                "source": ref_file,
+                "node": node,
+                "graphnode": reference_node,
+                "param": "reference_file",
+                "files": []
+            }
 
             ref_file_name = os.path.basename(ref_file)
             if "%04d" in ref_file_name:
-                ref_files = self.get_sequence(ref_file)
-                item["files"].extend(ref_files)
+                item["files"] = self.get_sequence(ref_file)
             else:
-                item["files"].append(ref_file)
+                if os.path.exists(ref_file) and os.path.isfile(ref_file):
+                    item["files"] = [ref_file]
+
+            if not item["files"]:
+                self.log.warning("Reference node '%s' has no valid file "
+                                 "path set: %s" % (reference_node, ref_file))
+                # TODO: This should allow to pass and fail in Validator instead
+                raise RuntimeError("Reference node  must be a full file path!")
 
             resources.append(item)
 

--- a/colorbleed/plugins/maya/publish/collect_yeti_rig.py
+++ b/colorbleed/plugins/maya/publish/collect_yeti_rig.py
@@ -196,9 +196,17 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
         return resources
 
     def search_textures(self, filepath):
-        """Search the texture source files in the image search paths.
+        """Search all texture files on disk.
 
-        This also parses to full sequences.
+        This also parses to full sequences for those with dynamic patterns
+        like <UDIM> and %04d in the filename.
+
+        Args:
+            filepath (str): The full path to the file, including any
+                dynamic patterns like <UDIM> or %04d
+
+        Returns:
+            list: The files found on disk
 
         """
         filename = os.path.basename(filepath)
@@ -223,6 +231,7 @@ class CollectYetiRig(pyblish.api.InstancePlugin):
         # Assuming it is a fixed name (single file)
         if os.path.exists(filepath):
             return [filepath]
+
         return []
 
     def get_sequence(self, filename, pattern="%04d"):


### PR DESCRIPTION
Set up a draft to fix YETI-12, now supporting multiple image search paths for a Yeti Graph.