### PR TITLE
Default to world-space output for pointcache+animation, plus add toggle

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_animation.py
+++ b/colorbleed/plugins/maya/create/colorbleed_animation.py
@@ -32,3 +32,6 @@ class CreateAnimation(avalon.maya.Creator):
 
         # Include the groups above the out_SET content
         self.data["includeParentHierarchy"] = False  # Include parent groups
+
+        # Default to exporting world-space
+        self.data["worldSpace"] = True

--- a/colorbleed/plugins/maya/create/colorbleed_pointcache.py
+++ b/colorbleed/plugins/maya/create/colorbleed_pointcache.py
@@ -20,6 +20,7 @@ class CreatePointCache(avalon.maya.Creator):
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible
         self.data["includeParentHierarchy"] = False  # Include parent groups
+        self.data["worldSpace"] = True       # Default to exporting world-space
 
         # Add options for custom attributes
         self.data["attr"] = ""

--- a/colorbleed/plugins/maya/publish/extract_animation.py
+++ b/colorbleed/plugins/maya/publish/extract_animation.py
@@ -55,7 +55,8 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
             "writeVisibility": True,
             "writeCreases": True,
             "uvWrite": True,
-            "selection": True
+            "selection": True,
+            "worldSpace": instance.data.get("worldSpace", True)
         }
 
         if not instance.data.get("includeParentHierarchy", True):

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -57,7 +57,8 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
             "writeCreases": True,
             "writeColorSets": writeColorSets,
             "uvWrite": True,
-            "selection": True
+            "selection": True,
+            "worldSpace": instance.data.get("worldSpace", True)
         }
 
         if not instance.data.get("includeParentHierarchy", True):


### PR DESCRIPTION
With the support for `includeParentHierarchy` on pointcache and animation it meant that now all of a sudden transformations on parents got ignored, as they were removed. With this PR we're resolving this by defaulting to exporting in world-space and allowing a toggle on the instance in Maya to decide whether to export world-space or not.