### PR TITLE
Ignore input connections in Yeti input_SET that are rig internal

### DIFF
--- a/colorbleed/plugins/maya/publish/validate_yeti_rig_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_yeti_rig_settings.py
@@ -2,32 +2,46 @@ import pyblish.api
 
 
 class ValidateYetiRigSettings(pyblish.api.InstancePlugin):
+    """Validate Yeti Rig Settings have collected input connections.
+
+    The input connections are collected for the nodes in the `input_SET`.
+    When no input connections are found a warning is logged but it is allowed
+    to pass validation.
+
+    """
+
     order = pyblish.api.ValidatorOrder
-    label = "Validate Yeti Rig Settings"
+    label = "Yeti Rig Settings"
     families = ["colorbleed.yetiRig"]
 
     def process(self, instance):
 
         invalid = self.get_invalid(instance)
         if invalid:
-            raise RuntimeError("Detected invalid Yeti Rig data. "
+            raise RuntimeError("Detected invalid Yeti Rig data. (See log) "
                                "Tip: Save the scene")
 
     @classmethod
     def get_invalid(cls, instance):
 
-        rigsettings = instance.data.get("rigsettings", {})
-        if not rigsettings:
+        rigsettings = instance.data.get("rigsettings", None)
+        if rigsettings is None:
             cls.log.error("MAJOR ERROR: No rig settings found!")
             return True
 
         # Get inputs
         inputs = rigsettings.get("inputs", [])
+        if not inputs:
+            # Empty rig settings dictionary
+            cls.log.warning("No rig inputs found. This can happen when "
+                            "the rig has no inputs from outside the rig.")
+            return False
+
         for input in inputs:
             source_id = input["sourceID"]
             if source_id is None:
                 cls.log.error("Discovered source with 'None' as ID, please "
-                              "check if the input shape has an cbId")
+                              "check if the input shape has a cbId")
                 return True
 
             destination_id = input["destinationID"]


### PR DESCRIPTION
Fix an issue where some "input" connections to the nodes in the `input_SET` broke connections that are meant to be internal to the rig. Now this will only disconnect the inputs that are made to nodes outside of the published content.