### PR TITLE
Support Multiple Cameras per Renderlayer

### DIFF
--- a/colorbleed/plugins/global/publish/collect_filesequences.py
+++ b/colorbleed/plugins/global/publish/collect_filesequences.py
@@ -127,12 +127,9 @@ class CollectFileSequences(pyblish.api.ContextPlugin):
                 root = path
 
             self.log.info("Collecting: {}".format(root))
-            regex = data.get("regex")
-            if regex:
-                self.log.info("Using regex: {}".format(regex))
 
             collections = collect(root=root,
-                                  regex=regex,
+                                  regex=data.get("regex"),
                                   exclude_regex=data.get("exclude_regex"),
                                   startFrame=data.get("startFrame"),
                                   endFrame=data.get("endFrame"))

--- a/colorbleed/plugins/global/publish/submit_publish_job.py
+++ b/colorbleed/plugins/global/publish/submit_publish_job.py
@@ -142,9 +142,10 @@ class SubmitDependentImageSequenceJobDeadline(pyblish.api.InstancePlugin):
         data = instance.data.copy()
         subset = data["subset"]
         state = data.get("publishJobState", "Suspended")
-        job_name = "{batch} - {subset} [publish image sequence]".format(
-            batch=job["Props"]["Name"],
-            subset=subset
+
+        # Construct job name based on Render Job name and data.
+        job_name = "{name} [publish image sequence]".format(
+            name=job["Props"]["Name"],
         )
 
         # Get start/end frame from instance, if not available get from context
@@ -188,7 +189,7 @@ class SubmitDependentImageSequenceJobDeadline(pyblish.api.InstancePlugin):
         # Add upstream inputs tracking when data is present in instance
         inputs = instance.data.get("inputs")
         if inputs:
-            # Note that we are collecting the representation ids as 
+            # Note that we are collecting the representation ids as
             # strings so they can safely be converted to JSON
             metadata["inputs"] = inputs
 

--- a/colorbleed/plugins/maya/publish/collect_render_layer_aovs.py
+++ b/colorbleed/plugins/maya/publish/collect_render_layer_aovs.py
@@ -31,17 +31,14 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        # Check if Extend Frames is toggled
-        if not instance.data("extendFrames", False):
-            return
-
         # Get renderer
         renderer = instance.data["renderer"]
-        self.log.info("Renderer found: {}".format(renderer))
 
-        rp_node_types = {"vray": ["VRayRenderElement", "VRayRenderElementSet"],
-                         "arnold": ["aiAOV"],
-                         "redshift": ["RedshiftAOV"]}
+        rp_node_types = {
+            "vray": ["VRayRenderElement", "VRayRenderElementSet"],
+            "arnold": ["aiAOV"],
+            "redshift": ["RedshiftAOV"]
+        }
 
         if renderer not in rp_node_types.keys():
             self.log.error("Unsupported renderer found: '{}'".format(renderer))
@@ -62,12 +59,10 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
                 continue
 
             pass_name = self.get_pass_name(renderer, element)
-            render_pass = "%s.%s" % (instance.data["subset"], pass_name)
+            result.append(pass_name)
 
-            result.append(render_pass)
-
-        self.log.info("Found {} render elements / AOVs for "
-                      "'{}'".format(len(result), instance.data["subset"]))
+        self.log.debug("Found {} render elements / AOVs for "
+                       "'{}'".format(len(result), instance.data["subset"]))
 
         instance.data["renderPasses"] = result
 
@@ -82,18 +77,20 @@ class CollectRenderLayerAOVS(pyblish.api.InstancePlugin):
 
             # Support V-Ray extratex explicit name (if set by user)
             if pass_type == "extratex":
-            
+
                 explicit_attr = "{}.vray_explicit_name_extratex".format(node)
                 explicit_name = cmds.getAttr(explicit_attr)
                 if explicit_name:
                     return explicit_name
-                
+
                 # Somehow V-Ray appends the Texture node's name to the filename
-                connected_texture = cmds.listConnections(node + ".vray_texture_extratex",
+                texture_attr = node + ".vray_texture_extratex"
+                connected_texture = cmds.listConnections(texture_attr,
                                                          source=True,
                                                          destination=False)
                 if connected_texture:
-                    basename = cmds.getAttr("{}.{}".format(node, vray_node_attr))
+                    basename = cmds.getAttr("{}.{}".format(node,
+                                                           vray_node_attr))
                     return "{}_{}".format(basename, connected_texture[0])
 
             # Node type is in the attribute name but we need to check if value

--- a/colorbleed/plugins/maya/publish/collect_renderable_camera.py
+++ b/colorbleed/plugins/maya/publish/collect_renderable_camera.py
@@ -11,8 +11,7 @@ class CollectRenderableCamera(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.01
     label = "Collect Renderable Camera(s)"
     hosts = ["maya"]
-    families = ["colorbleed.vrayscene",
-                "colorbleed.renderlayer"]
+    families = ["colorbleed.vrayscene"]
 
     def process(self, instance):
         layer = instance.data["setMembers"]

--- a/colorbleed/plugins/maya/publish/collect_renderlayer_filenames.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayer_filenames.py
@@ -1,0 +1,138 @@
+import os
+import re
+
+import pyblish.api
+
+from maya import cmds
+from maya import mel
+
+from colorbleed.maya import lib
+
+
+def get_renderer_variables(renderlayer):
+    """Retrieve the extension and padding from render settings.
+
+    Args:
+        renderlayer (str): the node name of the renderlayer.
+
+    Returns:
+        dict
+    """
+
+    renderer = lib.get_renderer(renderlayer)
+    render_attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS["default"])
+    padding = cmds.getAttr("{node}.{padding}".format(**render_attrs))
+
+    if renderer == "vray":
+        # Maya's renderSettings function does not return V-Ray file extension
+        # so we get the extension from vraySettings
+        extension = cmds.getAttr("vraySettings.imageFormatStr")
+
+        # When V-Ray image format has not been switched once from default .png
+        # the getAttr command above returns None. As such we explicitly set
+        # it to `.png`
+        if extension is None:
+            extension = "png"
+
+    else:
+
+        # Get the extension, getAttr defaultRenderGlobals.imageFormat
+        # only returns an index number.
+        # todo: this should actually switch to the renderlayer to be accurate
+        # todo: needs fix for file extension for Arnold (mtoa!)
+        filename_0 = cmds.renderSettings(fullPath=True,
+                                         firstImageName=True)[0]
+        filename_base = os.path.basename(filename_0)
+        extension = os.path.splitext(filename_base)[-1].strip(".")
+
+    return {"ext": extension,
+            "padding": padding}
+
+
+class CollectRenderlayerFilenames(pyblish.api.InstancePlugin):
+    """Collect the renderlayer's output filenames"""
+
+    order = pyblish.api.CollectorOrder + 0.1
+    label = "Collect Renderlayer Filenames"
+    hosts = ["maya"]
+    families = ["colorbleed.renderlayer"]
+
+    def process(self, instance):
+
+        layer = instance.data["setMembers"]
+        renderer = instance.data["renderer"]
+
+        # Get the filename prefix attribute for current renderer
+        attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS["default"])
+        prefix_attr = "{node}.{prefix}".format(**attrs)
+        prefix = lib.get_attr_in_layer(prefix_attr, layer=layer)
+
+        # Use this mapping to resolve variables (case insensitive)
+        tokens = {
+            "<Camera>": "{camera}",
+            "<Scene>": "{scene}",
+            "<RenderLayer>": "{renderlayer}",
+            "<RenderPass>": "{renderpass}",
+
+            # V-Ray
+            "<Layer>": "{renderlayer}",
+        }
+
+        context = instance.context
+        filepath = context.data["currentFile"]
+        filename = os.path.basename(filepath)
+        scene = os.path.splitext(filename)[0]
+
+        # The output produces a 'nice name' for a <Camera> using its
+        # shortest unique path of the transform
+        camera = instance.data["camera"]
+        transform = cmds.ls(cmds.listRelatives(camera,
+                                               parent=True,
+                                               fullPath=True))[0]
+        camera_name = transform.replace(":", "_").replace("|", "_")
+
+        # Get the variables depending on the renderer
+        render_variables = get_renderer_variables(layer)
+
+        data = {
+            "scene": scene,
+            "renderlayer": instance.data["layername"],
+            "camera": camera_name,
+            "renderpass": "{renderpass}"    # We format this later per AOV
+        }
+
+        # Format prefix with the data
+        prefix = prefix
+        for src, to in tokens.items():
+            prefix = re.sub(re.escape(src), to, prefix, flags=re.IGNORECASE)
+        prefix = prefix.format(**data)
+        has_pass_in_prefix = "{renderpass}" in prefix
+
+        # Construct full file paths
+        padding = "#" * render_variables["padding"]
+        extension = render_variables["ext"]
+
+        workspace = context.data["workspaceDir"]
+        render_root = os.path.join(workspace, "renders")
+
+        filenames = []
+        for renderpass in [None] + instance.data.get("renderPasses", []):
+
+            # The first entry is the "beauty" pass. (Main render)
+            is_beauty_pass = renderpass is None
+            if is_beauty_pass:
+                renderpass = "beauty"
+
+            # Base of the output filepath
+            path = os.path.join(render_root,
+                                prefix.format(renderpass=renderpass))
+
+            if not has_pass_in_prefix and not is_beauty_pass:
+                path += "." + renderpass
+
+            # Add frame padding and extension
+            path += "." + padding + "." + extension
+
+            filenames.append(path)
+
+        instance.data["filenames"] = filenames

--- a/colorbleed/plugins/maya/publish/validate_render_filename_prefix.py
+++ b/colorbleed/plugins/maya/publish/validate_render_filename_prefix.py
@@ -1,0 +1,91 @@
+import maya.cmds as cmds
+
+import pyblish.api
+import colorbleed.api
+import colorbleed.maya.lib as lib
+
+
+class ValidateRenderFilenamePrefix(pyblish.api.InstancePlugin):
+    """Validate the render filename prefix is set as required.
+
+    Note:
+        The required filename prefix differs when you are rendering more
+        than a single camera from a renderlayer.
+
+    """
+
+    order = colorbleed.api.ValidateContentsOrder
+    label = "Render Filename Prefix"
+    hosts = ["maya"]
+    families = ["colorbleed.renderlayer"]
+    actions = [colorbleed.api.RepairAction]
+
+    settings = {
+        # Single Camera renders
+        "single": {
+            "vray": "<Scene>/<Scene>_<Layer>/<Layer>",
+            "arnold": "<Scene>/<Scene>_<RenderLayer>/"
+                      "<RenderLayer>.<RenderPass>",
+            "default": "<Scene>/<Scene>_<RenderLayer>/<RenderLayer>"
+        },
+        # Multi Camera renders
+        "multi": {
+            "vray": "<Scene>/<Scene>_<Camera>_<Layer>/<Camera>_<Layer>",
+            "arnold": "<Scene>/<Scene>_<Camera>_<RenderLayer>/"
+                      "<Camera>_<RenderLayer>.<RenderPass>",
+            "default": "<Scene>/<Scene>_<Camera>_<RenderLayer>/"
+                       "<Camera>_<RenderLayer>"
+        }
+    }
+
+    def process(self, instance):
+
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise ValueError("Invalid render settings found for '%s'!"
+                             % instance.name)
+
+    @classmethod
+    def get_invalid(cls, instance):
+
+        renderer = instance.data["renderer"]
+        layer = instance.data["setMembers"]
+
+        # Get the current prefix value for the current renderer
+        attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS["default"])
+        prefix = lib.get_attr_in_layer("{node}.{prefix}".format(**attrs),
+                                       layer=layer)
+
+        required_prefix = cls._get_required_prefix(instance)
+        if prefix != required_prefix:
+            cls.log.error("Found: %s  - Expected: %s" % (prefix,
+                                                         required_prefix))
+            return [layer]
+
+    @classmethod
+    def repair(cls, instance):
+        """Set the required filename prefix"""
+
+        renderer = instance.data['renderer']
+        layer_node = instance.data['setMembers']
+
+        with lib.renderlayer(layer_node):
+
+            defaults = lib.RENDER_ATTRS['default']
+            attrs = lib.RENDER_ATTRS.get(renderer, defaults)
+            prefix_attr = "{node}.{prefix}".format(**attrs)
+
+            required_prefix = cls._get_required_prefix(instance)
+            cmds.setAttr(prefix_attr, required_prefix, type="string")
+
+    @classmethod
+    def _get_required_prefix(cls, instance):
+        """Helper method to get the correct prefix value from `settings`"""
+
+        renderer = instance.data["renderer"]
+        count = len(instance.data["cameras"])
+        key = "multi" if count > 1 else "single"
+        prefixes = cls.settings[key]
+
+        return prefixes.get(renderer, prefixes["default"])
+

--- a/colorbleed/plugins/maya/publish/validate_render_single_camera.py
+++ b/colorbleed/plugins/maya/publish/validate_render_single_camera.py
@@ -4,15 +4,7 @@ import colorbleed.maya.action
 
 
 class ValidateRenderSingleCamera(pyblish.api.InstancePlugin):
-    """Only one camera may be renderable in a layer.
-
-    Currently the pipeline supports only a single camera per layer.
-    This is because when multiple cameras are rendered the output files
-    automatically get different names because the <Camera> render token
-    is not in the output path. As such the output files conflict with how
-    our pipeline expects the output.
-
-    """
+    """Ensure at least a single camera is renderable."""
 
     order = colorbleed.api.ValidateContentsOrder
     label = "Render Single Camera"
@@ -33,9 +25,8 @@ class ValidateRenderSingleCamera(pyblish.api.InstancePlugin):
         cameras = instance.data.get("cameras", [])
 
         if len(cameras) > 1:
-            cls.log.error("Multiple renderable cameras found for %s: %s " %
-                          (instance.data["setMembers"], cameras))
-            return [instance.data["setMembers"]] + cameras
+            cls.log.warning("Multiple renderable cameras found for %s: %s " %
+                            (instance.data["setMembers"], cameras))
 
         elif len(cameras) < 1:
             cls.log.error("No renderable cameras found for %s " %

--- a/colorbleed/plugins/maya/publish/validate_renderlayer_aovs.py
+++ b/colorbleed/plugins/maya/publish/validate_renderlayer_aovs.py
@@ -28,10 +28,15 @@ class ValidateRenderLayerAOVs(pyblish.api.InstancePlugin):
     actions = [colorbleed.maya.action.SelectInvalidAction]
 
     def process(self, instance):
+
+        if not instance.data("extendFrames", False):
+            # This check is only relevant when extendFrames is enabled.
+            return
+
         invalid = self.get_invalid(instance)
         if invalid:
             raise RuntimeError("Found unregistered subsets: {}".format(invalid))
-    
+
     @classmethod
     def get_invalid(cls, instance):
 


### PR DESCRIPTION
Implement support for rendering multiple cameras per renderlayer through Deadline.

- When rendering a layer with multiple cameras the Filename prefix validator will validate a different prefix, one that includes the `<Camera> token. So this is explicitly included.
- The resulting publish's subset will be prefixed with the camera, `<Camera>_`
- A warning will still be shown in validation that you are rendering multiple cameras, just to make the artist aware - since it's so rare to render multiple cameras.
- Cameras with a single renderable camera will still result in the same output as before - as such this is backwards compatible.