### PR TITLE
Implement Remote Publish (for Maya)

### DIFF
--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -20,6 +20,7 @@ def install():
     avalon.register_plugin_path(avalon.Loader, LOAD_PATH)
 
     # Register default "local" target
+    print("Registering pyblish target: local")
     pyblish.register_target("local")
 
 

--- a/colorbleed/__init__.py
+++ b/colorbleed/__init__.py
@@ -19,8 +19,13 @@ def install():
     pyblish.register_plugin_path(PUBLISH_PATH)
     avalon.register_plugin_path(avalon.Loader, LOAD_PATH)
 
+    # Register default "local" target
+    pyblish.register_target("local")
+
 
 def uninstall():
     print("Deregistering global plug-ins..")
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     avalon.deregister_plugin_path(avalon.Loader, LOAD_PATH)
+
+    pyblish.deregister_target("local")

--- a/colorbleed/houdini/__init__.py
+++ b/colorbleed/houdini/__init__.py
@@ -44,7 +44,10 @@ def install():
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
     log.info("Setting default family states for loader..")
-    avalon.data["familiesStateToggled"] = ["colorbleed.imagesequence"]
+    avalon.data["familiesStateToggled"] = [
+        "colorbleed.imagesequence",
+        "colorbleed.review"
+    ]
 
     # Set asset FPS for the empty scene directly after launch of Houdini
     # so it initializes into the correct scene FPS

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -52,7 +52,10 @@ def install():
     override_event("taskChanged", on_task_changed)
 
     log.info("Setting default family states for loader..")
-    avalon.data["familiesStateToggled"] = ["colorbleed.imagesequence"]
+    avalon.data["familiesStateToggled"] = [
+        "colorbleed.imagesequence",
+        "colorbleed.review"
+    ]
 
 
 def uninstall():

--- a/colorbleed/maya/__init__.py
+++ b/colorbleed/maya/__init__.py
@@ -4,8 +4,11 @@ import weakref
 
 from maya import utils, cmds, mel
 
+from avalon.maya.pipeline import (
+    IS_HEADLESS,
+    _menu as avalon_menu
+)
 from avalon import api as avalon, pipeline, maya
-from avalon.maya.pipeline import IS_HEADLESS
 from pyblish import api as pyblish
 
 from ..lib import (
@@ -31,17 +34,19 @@ def install():
     avalon.register_plugin_path(avalon.Loader, LOAD_PATH)
     avalon.register_plugin_path(avalon.Creator, CREATE_PATH)
 
-    menu.install()
-
+    # The `init` callback is required in headless mode to load referenced
+    # Alembics correctly at rendertime without errors.
     log.info("Installing callbacks ... ")
     avalon.on("init", on_init)
 
-    # Callbacks below are not required for headless mode, the `init` however
-    # is important to load referenced Alembics correctly at rendertime.
+    # The other Callbacks below are not required for headless mode
+    # Also menus and other UI cosmetics can be ignored in batch mode.
     if IS_HEADLESS:
         log.info("Running in headless mode, skipping Colorbleed Maya "
                  "save/open/new callback installation..")
         return
+
+    menu.install()
 
     avalon.on("save", on_save)
     avalon.on("open", on_open)
@@ -107,6 +112,11 @@ def on_init(_):
     cmds.loadPlugin("AbcImport", quiet=True)
     cmds.loadPlugin("AbcExport", quiet=True)
 
+    # Process everything below only when not in headless batch mode
+    # since they are purely cosmetic UI changes for the artists.
+    if IS_HEADLESS:
+        return
+
     # Force load objExport plug-in (requested by artists)
     cmds.loadPlugin("objExport", quiet=True)
 
@@ -115,9 +125,10 @@ def on_init(_):
         override_toolbox_ui
     )
     safe_deferred(override_component_mask_commands)
+    safe_deferred(override_toolbox_ui)
 
-    if not IS_HEADLESS:
-        safe_deferred(override_toolbox_ui)
+    # Add extra menu entry to Maya's Avalon Menu for "Remote Publish..."
+    safe_deferred(_add_remote_publish_to_avalon_menu)
 
 
 def on_before_save(return_code, _):
@@ -210,3 +221,39 @@ def on_task_changed(*args):
 
     # Run
     maya.pipeline._on_task_changed()
+
+
+def _add_remote_publish_to_avalon_menu():
+    """Add 'Remote Publish...' to Avalon menu"""
+
+    log.info("Customize Avalon menu: Refactor publish menu items..")
+
+    def _get_maya_menu_item_with_label(menu, label):
+        """Return menu item in menu that matches label"""
+        items = cmds.menu(avalon_menu, query=True, itemArray=True)
+        for item in items:
+            item_label = cmds.menuItem(item, query=True, label=True)
+            if item_label == label:
+                return item
+
+    # Get "Publish..." menu item
+    publish_menu_item = _get_maya_menu_item_with_label(
+        menu=avalon_menu,
+        label="Publish..."
+    )
+
+    # Copy icon from the Publish menu item..
+    icon = cmds.menuItem(publish_menu_item,
+                         query=True,
+                         image=True)
+
+    import pyblish_qml
+    cmds.menuItem("Remote publish...",
+                  command=lambda *args: pyblish_qml.show(
+                      targets=["default", "deadline"]
+                  ),
+                  image=icon,
+                  annotation="Submit scene to renderfarm to "
+                             "be published there..",
+                  insertAfter=publish_menu_item,
+                  parent=avalon_menu)

--- a/colorbleed/plugin.py
+++ b/colorbleed/plugin.py
@@ -18,6 +18,7 @@ class Extractor(pyblish.api.InstancePlugin):
     """
 
     order = 2.0
+    targets = ["local"]  # Only extract when target is "local"
 
     def staging_dir(self, instance):
         """Provide a temporary directory in which to store extracted files

--- a/colorbleed/plugins/global/publish/collect_project_code.py
+++ b/colorbleed/plugins/global/publish/collect_project_code.py
@@ -1,6 +1,7 @@
 import pyblish.api
 import avalon.io as io
 
+
 class CollectProjectCode(pyblish.api.ContextPlugin):
     """Collect the Project code from database project.data["config"]
 

--- a/colorbleed/plugins/global/publish/integrate.py
+++ b/colorbleed/plugins/global/publish/integrate.py
@@ -37,7 +37,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "colorbleed.rig",
                 "colorbleed.vrayproxy",
                 "colorbleed.yetiRig",
-                "colorbleed.yeticache"]
+                "colorbleed.yeticache",
+                "colorbleed.review"]
 
     def process(self, instance):
 

--- a/colorbleed/plugins/global/publish/integrate.py
+++ b/colorbleed/plugins/global/publish/integrate.py
@@ -39,6 +39,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "colorbleed.yetiRig",
                 "colorbleed.yeticache",
                 "colorbleed.review"]
+    targets = ["local"]
 
     def process(self, instance):
 

--- a/colorbleed/plugins/maya/create/colorbleed_review.py
+++ b/colorbleed/plugins/maya/create/colorbleed_review.py
@@ -1,0 +1,28 @@
+from collections import OrderedDict
+import avalon.maya
+
+from colorbleed.maya import lib
+
+
+class CreateReview(avalon.maya.Creator):
+    """Create a quicktime .mov reviewable"""
+
+    name = "reviewDefault"
+    label = "Review"
+    family = "colorbleed.review"
+    icon = "video-camera"
+
+    def __init__(self, *args, **kwargs):
+        super(CreateReview, self).__init__(*args, **kwargs)
+
+        # Get basic animation data (start frame, end frame, etc.)
+        for key, value in lib.collect_animation_data().items():
+            self.data[key] = value
+
+        # Remove substeps
+        self.data.pop("step", None)
+
+        self.data["include_alpha"] = False
+
+        # todo: overridable resolution per instance
+        # todo: overridable viewport settings per instance

--- a/colorbleed/plugins/maya/load/load_vdb_to_vray.py
+++ b/colorbleed/plugins/maya/load/load_vdb_to_vray.py
@@ -92,12 +92,25 @@ class LoadVDBtoVRay(api.Loader):
         else:
             # The path points to the publish .vdb sequence folder so we
             # find the first file in there that ends with .vdb
-            files = sorted(os.listdir(path))
-            first = next((x for x in files if x.endswith(".vdb")), None)
-            if first is None:
-                raise RuntimeError("Couldn't find first .vdb file of "
-                                   "sequence in: %s" % path)
-            filename = os.path.join(path, first)
+            files = sorted(x for x in os.listdir(path) if x.endswith(".vdb"))
+            if not files:
+                raise RuntimeError("Couldn't find .vdb files in: %s" % path)
+
+            if len(files) == 1:
+                # Ensure check for single file is also done in folder
+                fname = files[0]
+            else:
+                # Sequence
+                from avalon.vendor import clique
+                # todo: check support for negative frames as input
+                collections, remainder = clique.assemble(files)
+                assert len(collections) == 1, (
+                    "Must find a single image sequence, "
+                    "found: %s" % (collections,)
+                )
+                fname = collections[0].format('{head}{padding}{tail}')
+
+            filename = os.path.join(path, fname)
 
         # Suppress preset pop-up if we want.
         popup_attr = "{0}.inDontOfferPresets".format(grid_node)

--- a/colorbleed/plugins/maya/publish/extract_quicktime.py
+++ b/colorbleed/plugins/maya/publish/extract_quicktime.py
@@ -1,0 +1,185 @@
+import os
+import subprocess
+import contextlib
+import json
+
+import avalon.maya
+from avalon.vendor import clique
+
+import colorbleed.api
+
+from maya import cmds, mel
+import capture_gui.lib
+
+# todo: replace with ffmpeg-python so it's public
+import capture_gui_cb.ffmpeg as cb_ffmpeg
+
+
+def _get_focal_length(cam, start, end):
+    plug = "{0}.focalLength".format(cam)
+    if not cmds.listConnections(plug, destination=False, source=True):
+        # static
+        return cmds.getAttr(plug)
+    else:
+        # dynamic
+        return [cmds.getAttr(plug, time=t) for t in range(int(start),
+                                                          int(end))]
+
+
+class ExtractQuicktime(colorbleed.api.Extractor):
+    """Extract Quicktime from viewport capture.
+
+    Takes review camera and creates review Quicktime video based on viewport
+    capture.
+
+    """
+
+    label = "Quicktime"
+    hosts = ["maya"]
+    families = ["colorbleed.review"]
+
+    def process(self, instance):
+        self.log.info("Extracting capture..")
+
+        # Get scene FPS
+        fps = mel.eval('currentTimeUnitToFPS()')
+
+        # Get time range
+        start = instance.data["startFrame"]
+        end = instance.data["endFrame"]
+        handles = instance.data.get("handles", 0)
+        if handles:
+            start -= handles
+            end += handles
+
+        # Get camera
+        members = instance.data['setMembers']
+        cameras = cmds.ls(members, leaf=True, shapes=True, long=True,
+                          dag=True, type="camera")
+        assert len(cameras) == 1, "Not a single camera found in extraction"
+        camera = cameras[0]
+
+        # Get settings
+        include_alpha = instance.data.get("include_alpha", False)
+
+        # Define capture options
+        # Override some preset defaults
+        preset = {}
+        preset['camera'] = camera
+        preset['start_frame'] = start
+        preset['end_frame'] = end
+        preset['show_ornaments'] = False    # Don't draw any Maya HUD
+
+        # Extract to image sequence, then we convert afterwards with ffmpeg
+        preset['off_screen'] = True
+        preset['format'] = "image"
+        preset['quality'] = 95
+
+        if include_alpha:
+            preset["compression"] = "png"
+        else:
+            preset['compression'] = "jpg"
+
+        preset['camera_options'] = {
+            "displayGateMask": False,
+            "displayResolution": False,
+            "displayFilmGate": False,
+            "displayFieldChart": False,
+            "displaySafeAction": False,
+            "displaySafeTitle": False,
+            "displayFilmPivot": False,
+            "displayFilmOrigin": False,
+            "overscan": 1.0,
+            "depthOfField": cmds.getAttr("{0}.depthOfField".format(camera)),
+        }
+
+        self.log.info('using viewport preset: {}'.format(preset))
+        # todo: state of ambient occlusion, lighting, double sided, etc?
+
+        stagingdir = self.staging_dir(instance)
+        filename = "{0}".format(instance.name)
+        path = os.path.join(stagingdir, filename)
+        self.log.info("Outputting images to %s" % path)
+
+        preset['filename'] = path
+
+        # It always writes to a new staging dir so we should never be
+        # overwriting anything
+        preset['overwrite'] = False
+
+        with maintained_time():
+            playblast = capture_gui.lib.capture_scene(preset)
+
+        self.log.info("file list  {}".format(playblast))
+        assert playblast, "Playblast likely interrupted.."
+
+        # Collect playblasted frames
+        collected_frames = os.listdir(stagingdir)
+        # todo: support negative frames as input
+        collections, remainder = clique.assemble(collected_frames)
+        assert not remainder, (
+            "Remaining frames found, this is incorrect.. (or negative frames?)"
+        )
+        assert len(collections) == 1, (
+            "Must find a single image sequence, found: %s" % (collections,)
+        )
+
+        input_path = os.path.join(
+            stagingdir, collections[0].format('{head}{padding}{tail}'))
+        self.log.info("input {}".format(input_path))
+
+        movie_file = filename + ".mov"
+        movie_file_burnin = filename + ".burnin" + ".mov"
+
+        full_movie_path = os.path.join(stagingdir, movie_file)
+        full_burnin_path = os.path.join(stagingdir, movie_file_burnin)
+
+        self.log.info("output {}".format(full_movie_path))
+
+        with avalon.maya.suspended_refresh():
+
+            # Render ffmpeg without burnin
+            self.log.info("Creating video..")
+            cb_ffmpeg.render(source=input_path,
+                             output=full_movie_path,
+                             fps=fps,       # for image sequence FPS
+                             start=start,   # for image sequence start frame
+                             logo=False,
+                             include_alpha=include_alpha,
+                             # Hide the subprocess window
+                             create_no_window=True,
+                             verbose=True)
+
+            # Render ffmpeg with burnin
+            self.log.info("Creating burnin video..")
+            scene = os.path.basename(instance.context.data["currentFile"])
+            cb_ffmpeg.overlay_video(source=input_path,
+                                    output=full_burnin_path,
+                                    start=start,
+                                    end=end,
+                                    scene=scene,
+                                    username="",
+                                    focal_length=_get_focal_length(camera,
+                                                                   start,
+                                                                   end),
+                                    fps=fps,
+                                    include_alpha=include_alpha,
+                                    # Hide the subprocess window
+                                    create_no_window=True,
+                                    verbose=True)
+
+        if "files" not in instance.data:
+            instance.data["files"] = []
+
+        # Store both the version without burnin and with burnin
+        instance.data["files"].append(movie_file)
+        instance.data["files"].append(movie_file_burnin)
+
+
+@contextlib.contextmanager
+def maintained_time():
+    ct = cmds.currentTime(query=True)
+    try:
+        yield
+    finally:
+        cmds.currentTime(ct, edit=True)

--- a/colorbleed/plugins/maya/publish/integrate_dailies.py
+++ b/colorbleed/plugins/maya/publish/integrate_dailies.py
@@ -1,0 +1,57 @@
+import os
+
+import pyblish.api
+
+import avalon.api as api
+import colorbleed.vendor.speedcopy as speedcopy
+
+
+class IntegrateDailies(pyblish.api.InstancePlugin):
+    """Integrate a copy of the content to the /dailies folder.
+
+    This is a temporary plug-in to allow quick reviewing and a constant file
+    location for the very latest version.
+
+    """
+
+    label = "Integrate Dailies"
+    order = pyblish.api.IntegratorOrder + 0.05
+    families = ["colorbleed.review"]
+
+    def process(self, instance):
+
+        context = instance.context
+        # Atomicity
+        #
+        # Guarantee atomic publishes - each asset contains
+        # an identical set of members.
+        #     __
+        #    /     o
+        #   /       \
+        #  |    o    |
+        #   \       /
+        #    o   __/
+        #
+        assert all(result["success"] for result in context.data["results"]), (
+            "Atomicity not held, aborting.")
+
+        # Define filepath for dailies
+        root = "{AVALON_PROJECTS}/{AVALON_PROJECT}/" \
+               "resources/dailies".format(**api.Session)
+        prefix = "{AVALON_ASSET}_{AVALON_TASK}".format(**api.Session)
+
+        for filename in instance.data["files"]:
+            staging = instance.data["stagingDir"]
+            source = os.path.join(staging, filename)
+
+            destination = os.path.join(root, "{0}_{1}".format(prefix,
+                                                              filename))
+
+            self.log.info("Copy daily: {0} -> {1}".format(source, destination))
+
+            if os.path.exists(destination) and os.path.isfile(destination):
+                # Remove existing file
+                self.log.debug("Overwriting existing file..")
+                #    os.remove(destination)
+
+            speedcopy.copyfile(source, destination)

--- a/colorbleed/plugins/maya/publish/integrate_dailies.py
+++ b/colorbleed/plugins/maya/publish/integrate_dailies.py
@@ -17,6 +17,7 @@ class IntegrateDailies(pyblish.api.InstancePlugin):
     label = "Integrate Dailies"
     order = pyblish.api.IntegratorOrder + 0.05
     families = ["colorbleed.review"]
+    targets = ["local"]
 
     def process(self, instance):
 

--- a/colorbleed/plugins/maya/publish/submit_maya_publish_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_maya_publish_deadline.py
@@ -1,0 +1,142 @@
+import os
+import json
+import getpass
+
+from maya import cmds
+
+from avalon import api, io
+from avalon.vendor import requests
+
+import pyblish.api
+
+import colorbleed.maya.lib as lib
+
+
+def _get_script():
+    """Get path to the deadline script to run"""
+
+    import pkgutil
+
+    module = "colorbleed.scripts.publish_instances"
+    loader = pkgutil.get_loader(module)
+    if not loader:
+        raise RuntimeError("Couldn't resolve module '%s'" % module)
+
+    module_path = loader.filename
+    if module_path.endswith(".pyc"):
+        module_path = module_path[:-len(".pyc")] + ".py"
+
+    return module_path
+
+
+class MayaSubmitPublishDeadline(pyblish.api.ContextPlugin):
+    """Submit Maya scene to perform a local publish in Deadline.
+
+    Publishing in Deadline can be helpful for scenes that publish very slow.
+    This way it can process in the background on another machine without the
+    Artist having to wait for the publish to finish on their local machine.
+
+    Submission is done through the Deadline Web Service as
+    supplied via the environment variable AVALON_DEADLINE.
+
+    """
+
+    label = "Submit Scene to Deadline"
+    order = pyblish.api.IntegratorOrder
+    hosts = ["maya"]
+    families = ["*"]
+    targets = ["deadline"]
+
+    def process(self, context):
+
+        # Ensure no errors so far
+        assert all(result["success"] for result in context.data["results"]), (
+            "Errors found, aborting integration..")
+
+        # Deadline connection
+        AVALON_DEADLINE = api.Session.get("AVALON_DEADLINE",
+                                          "http://localhost:8082")
+        assert AVALON_DEADLINE, "Requires AVALON_DEADLINE"
+
+        # Note that `publish` data member might change in the future.
+        # See: https://github.com/pyblish/pyblish-base/issues/307
+        actives = [i for i in context if i.data["publish"]]
+        instance_names = sorted(instance.name for instance in actives)
+
+        if not instance_names:
+            self.log.warning("No active instances found. "
+                             "Skipping submission..")
+            return
+
+        scene = context.data["currentFile"]
+        scenename = os.path.basename(scene)
+
+        # Get project code
+        project = io.find_one({"type": "project"})
+        code = project["data"].get("code", project["name"])
+
+        job_name = "{scene} [PUBLISH]".format(scene=scenename)
+        batch_name = "{code} - {scene}".format(code=code, scene=scenename)
+        deadline_user = "roy"  # todo: get deadline user dynamically
+
+        # Generate the payload for Deadline submission
+        payload = {
+            "JobInfo": {
+                "Plugin": "MayaBatch",
+                "BatchName": batch_name,
+                "Priority": 50,
+                "Name": job_name,
+                "UserName": deadline_user,
+                # "Comment": instance.context.data.get("comment", ""),
+                # "InitialStatus": state
+
+            },
+            "PluginInfo": {
+
+                "Build": None,  # Don't force build
+                "StrictErrorChecking": True,
+                "ScriptJob": True,
+
+                # Inputs
+                "SceneFile": scene,
+                "ScriptFilename": _get_script(),
+
+                # Mandatory for Deadline
+                "Version": cmds.about(version=True),
+
+                # Resolve relative references
+                "ProjectPath": cmds.workspace(query=True,
+                                              rootDirectory=True),
+
+            },
+
+            # Mandatory for Deadline, may be empty
+            "AuxFiles": []
+        }
+
+        # Include critical environment variables with submission + api.Session
+        keys = [
+            # Submit along the current Avalon tool setup that we launched
+            # this application with so the Render Slave can build its own
+            # similar environment using it, e.g. "maya2018;vray4.x;yeti3.1.9"
+            "AVALON_TOOLS",
+        ]
+        environment = dict({key: os.environ[key] for key in keys
+                            if key in os.environ}, **api.Session)
+        environment["PYBLISH_ACTIVE_INSTANCES"] = ",".join(instance_names)
+
+        payload["JobInfo"].update({
+            "EnvironmentKeyValue%d" % index: "{key}={value}".format(
+                key=key,
+                value=environment[key]
+            ) for index, key in enumerate(environment)
+        })
+
+        self.log.info("Submitting..")
+        self.log.info(json.dumps(payload, indent=4, sort_keys=True))
+
+        # E.g. http://192.168.0.1:8082/api/jobs
+        url = "{}/api/jobs".format(AVALON_DEADLINE)
+        response = requests.post(url, json=payload)
+        if not response.ok:
+            raise Exception(response.text)

--- a/colorbleed/plugins/maya/publish/submit_maya_render_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_maya_render_deadline.py
@@ -58,18 +58,24 @@ def get_renderer_variables(renderlayer):
             "filename_0": filename_0}
 
 
-class MayaSubmitDeadline(pyblish.api.InstancePlugin):
+class MayaSubmitRenderDeadline(pyblish.api.InstancePlugin):
     """Submit available render layers to Deadline
 
     Renders are submitted to a Deadline Web Service as
-    supplied via the environment variable AVALON_DEADLINE
+    supplied via the environment variable AVALON_DEADLINE.
+
+    Target "local":
+        Even though this does *not* render locally this is seen as
+        a 'local' submission as it is the regular way of submitting
+        a Maya render locally.
 
     """
 
-    label = "Submit to Deadline"
+    label = "Submit Render to Deadline"
     order = pyblish.api.IntegratorOrder
     hosts = ["maya"]
     families = ["colorbleed.renderlayer"]
+    targets = ["local"]
 
     def process(self, instance):
 

--- a/colorbleed/plugins/maya/publish/submit_vray_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_vray_deadline.py
@@ -17,7 +17,7 @@ class VraySubmitDeadline(pyblish.api.InstancePlugin):
     vrscene files will be written out based on the following template:
         <project>/vrayscene/<Scene>/<Scene>_<Layer>/<Layer>
 
-    A dependency job will be added for each layer to render the framer
+    A dependency job will be added for each layer to render the frames
     through VRay Standalone
 
     """
@@ -25,6 +25,7 @@ class VraySubmitDeadline(pyblish.api.InstancePlugin):
     order = pyblish.api.IntegratorOrder
     hosts = ["maya"]
     families = ["colorbleed.vrayscene"]
+    targets = ["local"]
 
     def process(self, instance):
 

--- a/colorbleed/plugins/maya/publish/validate_camera_contents.py
+++ b/colorbleed/plugins/maya/publish/validate_camera_contents.py
@@ -16,21 +16,22 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
     """
 
     order = colorbleed.api.ValidateContentsOrder
-    families = ['colorbleed.camera']
-    hosts = ['maya']
-    label = 'Camera Contents'
+    families = ["colorbleed.camera",
+                "colorbleed.review"]
+    hosts = ["maya"]
+    label = "Camera Contents"
     actions = [colorbleed.maya.action.SelectInvalidAction]
 
     @classmethod
     def get_invalid(cls, instance):
 
         # get cameras
-        members = instance.data['setMembers']
+        members = instance.data["setMembers"]
         shapes = cmds.ls(members, dag=True, shapes=True, long=True)
 
         # single camera
         invalid = []
-        cameras = cmds.ls(shapes, type='camera', long=True)
+        cameras = cmds.ls(shapes, type="camera", long=True)
         if len(cameras) != 1:
             cls.log.warning("Camera instance must have a single camera. "
                             "Found {0}: {1}".format(len(cameras), cameras))
@@ -43,7 +44,7 @@ class ValidateCameraContents(pyblish.api.InstancePlugin):
                 raise RuntimeError("No cameras in instance.")
 
         # non-camera shapes
-        valid_shapes = cmds.ls(shapes, type=('camera', 'locator'), long=True)
+        valid_shapes = cmds.ls(shapes, type=("camera", "locator"), long=True)
         shapes = set(shapes) - set(valid_shapes)
         if shapes:
             shapes = list(shapes)

--- a/colorbleed/plugins/maya/publish/validate_frame_range.py
+++ b/colorbleed/plugins/maya/publish/validate_frame_range.py
@@ -20,6 +20,7 @@ class ValidateFrameRange(pyblish.api.InstancePlugin):
     families = ["colorbleed.animation",
                 "colorbleed.pointcache",
                 "colorbleed.camera",
+                "colorbleed.review",
                 "colorbleed.renderlayer",
                 "oolorbleed.vrayproxy"]
 

--- a/colorbleed/plugins/maya/publish/validate_remote_allowed_families.py
+++ b/colorbleed/plugins/maya/publish/validate_remote_allowed_families.py
@@ -1,0 +1,32 @@
+import pyblish.api
+
+
+class ValidateRemoteAllowedFamilies(pyblish.api.InstancePlugin):
+    """This invalidates instances for publishing on the farm.
+
+    This means the publishing of the family cannot be done in a standalone
+    application. As such to publish these instances you'll have to run
+    a regular local publish.
+
+    Please use `Avalon > Publish...` instead.
+
+    """
+
+    label = "Remote Disallowed Families"
+    families = ["colorbleed.review"]
+    targets = ["deadline"]
+    order = pyblish.api.ValidatorOrder - 0.4  # Show error as early as possible
+
+    def process(self, instance):
+
+        # Get the families of the instance
+        families = instance.data.get("families", [])
+        family = instance.data.get("family", None)  # backwards compatibility
+        if family:
+            families.append(family)
+        families = set(families)
+
+        invalid_families = families.intersection(self.families)
+
+        raise RuntimeError("Family is not supported for publishing on "
+                           "farm: %s" % list(invalid_families))

--- a/colorbleed/plugins/maya/publish/validate_review_negative_frames.py
+++ b/colorbleed/plugins/maya/publish/validate_review_negative_frames.py
@@ -1,0 +1,26 @@
+import pyblish.api
+import colorbleed.api
+
+
+class ValidateReviewNegativeFrames(pyblish.api.InstancePlugin):
+    """Review does not support negative frames (for encoding).
+
+    Check with tech-department if you need this implemented now.
+
+    """
+
+    order = colorbleed.api.ValidatePipelineOrder
+    label = 'Review Negative Frames'
+    hosts = ['maya']
+    families = ["colorbleed.review"]
+    optional = False
+
+    def process(self, instance):
+
+        start_frame = instance.data["startFrame"]
+        handles = instance.data.get("handles", 0)
+
+        start = start_frame - handles
+        if start < 0:
+            raise RuntimeError("Review family currently does not support"
+                               "negative frames. (This includes the 'handles'")

--- a/colorbleed/scripts/publish_instances.py
+++ b/colorbleed/scripts/publish_instances.py
@@ -1,0 +1,92 @@
+try:
+    import logging
+    import pyblish.api
+    import pyblish.util
+except ImportError as exc:
+    # Ensure Deadline fails by output an error that contains "Fatal Error:"
+    raise ImportError("Fatal Error: %s" % exc)
+
+
+handler = logging.basicConfig()
+log = logging.getLogger("Publish active instances")
+log.setLevel(logging.DEBUG)
+
+
+class CollectInstancesActiveState(pyblish.api.ContextPlugin):
+    """Collect instance active state from PYBLISH_ACTIVE_INSTANCES.
+
+    This will read the PYBLISH_ACTIVE_INSTANCES environment variable and split
+    the string by comma. Only those instances that match by name with the
+    entries in that list will remain active for publishing, the rest will
+    be deactivated.
+
+    """
+    order = pyblish.api.CollectorOrder + 0.499
+
+    def process(self, context):
+
+        active = os.environ.get("PYBLISH_ACTIVE_INSTANCES")
+        if not active:
+            raise RuntimeError("No registered active instances to process"
+                               " in PYBLISH_ACTIVE_INSTANCES.")
+
+        # Make set of valid entries, split by comma
+        active = set(name.strip() for name in active.split(",") if
+                     name.strip())
+
+        found = set()
+        for instance in context:
+
+            # Set the state per instance
+            state = instance.name in active
+            self.log.info("Setting %s publish state to %s" % (instance.name,
+                                                              state))
+            instance.data["active"] = state
+            instance.data["publish"] = state
+
+            if state:
+                found.add(instance.name)
+
+        # Ensure all PYBLISH_ACTIVE_INSTANCES are found so that we can
+        # expect the publish to be consistent with what the user requested
+        missing = active - found
+        if missing:
+            raise RuntimeError("Missing subsets: %s" % list(missing))
+
+
+def publish():
+    # Note: This function assumes Avalon has been installed prior to this.
+    #       As such it does *not* trigger avalon.api.install().
+
+    # First register the plug-in that ensures only the instances defined in
+    # PYBLISH_ACTIVE_INSTANCES remain enabled directly after collection.
+    pyblish.api.register_plugin(CollectInstancesActiveState)
+
+    context = pyblish.util.publish()
+
+    # Cleanup afterwards, just to be sure. This is not so important if this
+    # runs in a standalone process that dies after publishing anyway.
+    pyblish.api.deregister_plugin(CollectInstancesActiveState)
+
+    print("Finished pyblish.util.publish(), checking for errors..")
+
+    if not context:
+        log.warning("Fatal Error: Nothing collected.")
+        sys.exit(1)
+
+    # Collect errors, {plugin name: error}
+    error_results = [r for r in context.data["results"] if r["error"]]
+
+    if error_results:
+        error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}"
+        for result in error_results:
+            log.error(error_format.format(**result))
+
+        log.error("Fatal Error: Errors occurred, see log..")
+        sys.exit(2)
+
+    print("All good. Success!")
+
+
+if __name__ == "__main__":
+    publish()


### PR DESCRIPTION
This PR implements *Remote Publish* inside Maya.

### What is it?

Remote Publishing allows to perform the publish of a scene through the Deadline renderfarm instead of having to wait on long-running extractions in your local scene.

- You can enable/disable instances inside the *Remote Publish...* publishing window and the farm will automatically pick up that only those instances in the scene should be published.
- Before submission to the farm your scene will run validation to ensure your scene will be most likely to succeed on the farm.
  * The farm-machine will also process everything, including collecting, validation, extraction and integration.

Reference:

- [Reference discussion on Gitter](https://gitter.im/pyblish/pyblish?at=5d2dcc0b01621760bcc4dcc8)

### How does it work?

It works by applying [Pyblish targets](https://api.pyblish.com/pages/targets.html). By default it will target `["default", "local"]` where `local` is the Extraction/Integration directly on the local machine, like it has always been. This is being [installed together with the config.install()](https://github.com/Colorbleed/colorbleed-config/compare/acre...BigRoy:farmpublish?expand=1#diff-7333a64b9671027aecb013de1447a022R23). 

However now there is an [additional Publish menu entry *Remote Publish...*](https://github.com/Colorbleed/colorbleed-config/commit/50e5b29601cf17804a4f69b20a0a8d0fc6a82dad) that targets `["default", "deadline"]` which has a [special Integrator that submits the scene to Deadline for Publishing](https://github.com/Colorbleed/colorbleed-config/compare/acre...BigRoy:farmpublish?expand=1#diff-af366fcf9323dd0a7e0161849c6bb270).

![remote_publish](https://user-images.githubusercontent.com/2439881/61304663-d2f4fc00-a7e9-11e9-9b3a-f1ac5a160fb1.jpg)

The farm-machine will open the scene, install avalon and run a little Python script that publishes the instances that were [submitted along](https://github.com/Colorbleed/colorbleed-config/compare/acre...BigRoy:farmpublish?expand=1#diff-af366fcf9323dd0a7e0161849c6bb270R126) as [`PYBLISH_ACTIVE_INSTANCES` environment variable](https://github.com/Colorbleed/colorbleed-config/compare/acre...BigRoy:farmpublish?expand=1#diff-27da0332a0faa92392de759f944f012cR28).

The submitted Deadline Job runs the _MayaBatch_ plug-in with a *ScriptJob* set for the Deadline job.

---

**Note** by accident three other commits sneaked in that are not required for the remote publish functionality:
- https://github.com/Colorbleed/colorbleed-config/commit/cafe58b2b26a92d16fa01d14a358c50f7461f593
- https://github.com/Colorbleed/colorbleed-config/commit/646f7971c7e33537bf6416c114b27b71ed121230
- https://github.com/Colorbleed/colorbleed-config/commit/3cd30c30fe661b316f3d118c2ef59b00b38aa240