### PR TITLE
Allow rendering + publishing of explicit custom frames list

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -478,8 +478,8 @@ class delete_after(object):
 
 
 def get_renderer(layer):
-    with renderlayer(layer):
-        return cmds.getAttr("defaultRenderGlobals.currentRenderer")
+    return get_attr_in_layer("defaultRenderGlobals.currentRenderer",
+                             layer=layer)
 
 
 def get_current_renderlayer():

--- a/colorbleed/plugins/global/publish/collect_filesequences.py
+++ b/colorbleed/plugins/global/publish/collect_filesequences.py
@@ -183,6 +183,12 @@ class CollectFileSequences(pyblish.api.ContextPlugin):
                     "currentFile": path
                 })
 
+                # When explicit frames are set from the custom frames list
+                # make sure we use those so we can validate explicitly
+                frames_explicit = data.get("frames", None)
+                if frames_explicit:
+                    instance.data["frames"] = frames_explicit
+
                 instance.append(collection)
 
                 self.log.debug("Collected instance:\n"

--- a/colorbleed/plugins/global/publish/submit_publish_job.py
+++ b/colorbleed/plugins/global/publish/submit_publish_job.py
@@ -186,6 +186,11 @@ class SubmitDependentImageSequenceJobDeadline(pyblish.api.InstancePlugin):
             }
         }
 
+        # Include explicitly chosen frames (if set)
+        frames_explicit = instance.data.get("frames", None)
+        if frames_explicit is not None:
+            metadata["frames"] = frames_explicit
+
         # Add upstream inputs tracking when data is present in instance
         inputs = instance.data.get("inputs")
         if inputs:
@@ -318,7 +323,7 @@ class SubmitDependentImageSequenceJobDeadline(pyblish.api.InstancePlugin):
         payload["JobInfo"]["Group"] = "publish"
 
         self.log.info("Submitting..")
-        self.log.info(json.dumps(payload, indent=4, sort_keys=True))
+        self.log.debug(json.dumps(payload, indent=4, sort_keys=True))
 
         url = "{}/api/jobs".format(AVALON_DEADLINE)
         response = requests.post(url, json=payload)

--- a/colorbleed/plugins/maya/create/colorbleed_renderglobals.py
+++ b/colorbleed/plugins/maya/create/colorbleed_renderglobals.py
@@ -48,6 +48,11 @@ class CreateRenderGlobals(avalon.maya.Creator):
         # We add a string "-" to allow the user to not set any secondary pools
         self.data["secondaryPool"] = ["-"] + pools
 
+        # Custom frame list so one can submit e.g. specific ranges
+        # of frames in one go: 1-100, 300-500
+        self.data["useCustomFrameList"] = False
+        self.data["frameList"] = ""
+
         self.options = {"useSelection": False}  # Force no content
 
     def process(self):

--- a/colorbleed/plugins/maya/publish/collect_renderlayer_custom_framelist.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayer_custom_framelist.py
@@ -1,0 +1,124 @@
+import os
+import re
+import subprocess
+
+import pyblish.api
+
+from maya import cmds
+from maya import mel
+
+from colorbleed.maya import lib
+
+
+CREATE_NO_WINDOW = 0x08000000
+
+
+def deadline_parse_framelist(framelist):
+    result = deadline_command("ParseFrameList", framelist)
+    frames = []
+    for entry in result.split(","):
+
+        # Clean any new-lines or spaces
+        entry = entry.strip()
+
+        # Match a single positive or negative number or a sequence
+        # defined as start-end which also supports negative ranges
+        # like -10--5 (-10 through to -5)
+        pattern = r"^(?P<start>-?[0-9]+)(?:(?:-)(?P<end>-?[0-9]+))?$"
+        match = re.match(pattern, entry)
+
+        start = int(match.group("start"))
+        end = match.group("end")
+        if end is None:
+            # Single frame (start)
+            frames.append(start)
+        else:
+            # Range of frames (start-end)
+            end = int(end)
+            frames.extend(range(start, end + 1))
+
+    return frames
+
+
+def deadline_command(*args):
+    # Find Deadline
+    path = os.environ.get("DEADLINE_PATH", None)
+    assert path is not None, "Variable 'DEADLINE_PATH' must be set"
+
+    executable = os.path.join(path, "deadlinecommand")
+    if os.name == "nt":
+        executable += ".exe"
+    assert os.path.exists(
+        executable), "Deadline executable not found at %s" % executable
+    query = [executable] + list(args)
+
+    process = subprocess.Popen(query, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE,
+                               universal_newlines=True,
+                               creationflags=CREATE_NO_WINDOW)
+    out, err = process.communicate()
+
+    return out
+
+
+class CollectRenderlayerCustomFramelist(pyblish.api.InstancePlugin):
+    """Collect the renderlayer's frame list set in renderglobalsDefault
+
+    This will collec the Custom Framelist value from the renderglobalsDefault
+    node for the specific renderlayer (as it could have a renderlayer override)
+
+    """
+
+    order = pyblish.api.CollectorOrder + 0.4999
+    label = "Render Framelist"
+    hosts = ["maya"]
+    families = ["colorbleed.renderlayer"]
+
+    def process(self, instance):
+
+        # Remove any collected data that other generic collectors have
+        # collected thus far.
+        instance.data.pop("useCustomFrameList", None)
+        instance.data.pop("frameList", None)
+
+        node = "renderglobalsDefault"
+        assert cmds.objExists(node), "renderglobalsDefault does not exist"
+
+        # Get the renderlayer for this instance
+        layer = instance.data["setMembers"]
+
+        # Get settings from renderGlobalsDefault node in that layer
+        use_frame_list = lib.get_attr_in_layer(node + ".useCustomFrameList",
+                                               layer=layer)
+        instance.data["useCustomFrameList"] = use_frame_list
+        if not use_frame_list:
+            return
+
+        frame_list = lib.get_attr_in_layer(node + ".frameList",
+                                           layer=layer).strip()
+
+        # Parse the actual frames with Deadline Command to ensure it's a
+        # valid framelist string.
+        frames = deadline_parse_framelist(frame_list)
+        frames = sorted(frames)
+
+        self.log.info("Collected custom framelist: %s" % frame_list)
+
+        instance.data["frameList"] = frame_list
+        instance.data["frames"] = frames
+
+        # Ensure start + end frame comes from the start/end
+        # of the explicit custom frame list formatting so the
+        # published data makes sense.
+        start = frames[0]
+        end = frames[-1]
+        self.log.info("Setting start and end frame: %s - %s" % (start, end))
+        instance.data["startFrame"] = start
+        instance.data["endFrame"] = end
+
+        # todo(roy): move this update label code elsewhere
+        # Update instance label for correct frame ranges
+        label = instance.data["label"]
+        base = label.rsplit("  [", 1)[0]    # split off frame range
+        label = "{0}  [{1}]".format(base, frame_list)
+        instance.data["label"] = label

--- a/colorbleed/plugins/maya/publish/collect_renderlayer_filenames.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayer_filenames.py
@@ -65,7 +65,11 @@ class CollectRenderlayerFilenames(pyblish.api.InstancePlugin):
         # Get the filename prefix attribute for current renderer
         attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS["default"])
         prefix_attr = "{node}.{prefix}".format(**attrs)
-        prefix = lib.get_attr_in_layer(prefix_attr, layer=layer)
+
+        # For some renderers when filename prefix has not been set the
+        # returned value is not a string but it returns None so we enforce
+        # an empty string for that case
+        prefix = lib.get_attr_in_layer(prefix_attr, layer=layer) or ""
 
         # Use this mapping to resolve variables (case insensitive)
         tokens = {

--- a/colorbleed/plugins/maya/publish/collect_renderlayer_filenames.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayer_filenames.py
@@ -9,7 +9,7 @@ from maya import mel
 from colorbleed.maya import lib
 
 
-def get_renderer_variables(renderlayer):
+def get_renderer_variables(renderer):
     """Retrieve the extension and padding from render settings.
 
     Args:
@@ -18,8 +18,8 @@ def get_renderer_variables(renderlayer):
     Returns:
         dict
     """
+    # todo: this function should get value in renderlayer to allow overrides
 
-    renderer = lib.get_renderer(renderlayer)
     render_attrs = lib.RENDER_ATTRS.get(renderer, lib.RENDER_ATTRS["default"])
     padding = cmds.getAttr("{node}.{padding}".format(**render_attrs))
 
@@ -92,7 +92,7 @@ class CollectRenderlayerFilenames(pyblish.api.InstancePlugin):
         camera_name = transform.replace(":", "_").replace("|", "_")
 
         # Get the variables depending on the renderer
-        render_variables = get_renderer_variables(layer)
+        render_variables = get_renderer_variables(renderer)
 
         data = {
             "scene": scene,

--- a/colorbleed/plugins/maya/publish/submit_maya_render_deadline.py
+++ b/colorbleed/plugins/maya/publish/submit_maya_render_deadline.py
@@ -119,6 +119,18 @@ class MayaSubmitRenderDeadline(pyblish.api.InstancePlugin):
         except OSError:
             pass
 
+        # Define the frame list
+        if instance.data.get("useCustomFrameList", False):
+            # Explicit custom frame list
+            frames = instance.data["frameList"]
+        else:
+            # StartFrame to EndFrame by byFrameStep
+            frames = "{start}-{end}x{step}".format(
+                    start=int(instance.data["startFrame"]),
+                    end=int(instance.data["endFrame"]),
+                    step=int(instance.data["byFrameStep"]),
+                )
+
         # Documentation for keys available at:
         # https://docs.thinkboxsoftware.com
         #    /products/deadline/8.0/1_User%20Manual/manual
@@ -135,11 +147,7 @@ class MayaSubmitRenderDeadline(pyblish.api.InstancePlugin):
                 "UserName": deadline_user,
 
                 "Plugin": instance.data.get("mayaRenderPlugin", "MayaBatch"),
-                "Frames": "{start}-{end}x{step}".format(
-                    start=int(instance.data["startFrame"]),
-                    end=int(instance.data["endFrame"]),
-                    step=int(instance.data["byFrameStep"]),
-                ),
+                "Frames": frames,
 
                 "Comment": comment
             },
@@ -210,12 +218,12 @@ class MayaSubmitRenderDeadline(pyblish.api.InstancePlugin):
         payload["JobInfo"].update(render_globals)
 
         plugin = payload["JobInfo"]["Plugin"]
-        self.log.info("using render plugin : {}".format(plugin))
+        self.log.info("Using render plugin : {}".format(plugin))
 
         self.preflight_check(instance)
 
         self.log.info("Submitting..")
-        self.log.info(json.dumps(payload, indent=4, sort_keys=True))
+        self.log.debug(json.dumps(payload, indent=4, sort_keys=True))
 
         # E.g. http://192.168.0.1:8082/api/jobs
         url = "{}/api/jobs".format(AVALON_DEADLINE)


### PR DESCRIPTION
This implements a feature where you can submit renders for specific frame ranges and publish it as a single full collection.

### How to use it?

To activate this use the `useCustomFrameList` on the `renderglobalsDefault` instance and then set the frame list value in the `frameList` string attribute.

The frame list should be formatted as a [Thinkbox Deadline Frame List Formatting](https://www.awsthinkbox.com/frame-list-formatting-options).

For example `1-20, 40-50` would render 1 through 20 and 40 through 50, having a `startFrame` of 1 and an `endFrame` of 50 however leaving a hole (skipping) frames 21 through 39.

---

#### Holes are now allowed in sequences, only when explicit frame numbers are provided

Note that this now also allows a published sequence to have "missing frames" however the idea is still that the `startFrame` and `endFrame` will remain the start and end of the full collection.

An explicit sorted `frames` list can be published along into the Avalon database (`[1, 2, 3, 4... 49, 50]`) so the database can store which frames it would happen to have and also identify which holes actually are correct. Currently this is **not yet!** published into the database, however the image sequence does get validated to ensure it matches the explicit input frames list.

---

#### Optimizations

This PR includes two very minor optimizations for the `get_renderer` queries so that there should be no more "Renderlayer switching" during Collecting to collect the relevant data. For heavy scenes that have are slow to switch renderlayers this should see quite a big speed increase in that regard.