### PR TITLE
Optimizations: allow excluding animated visible meshes for alembic if never visible + discard intermediate playblast files after encoding

### DIFF
--- a/colorbleed/maya/lib.py
+++ b/colorbleed/maya/lib.py
@@ -2245,3 +2245,208 @@ def get_shader_in_layer(node, layer):
     else:
         # Get the override for "defaultRenderLayer" (=masterLayer)
         return _get_override(connections, layer="defaultRenderLayer")
+
+
+@contextlib.contextmanager
+def maintained_time():
+    ct = cmds.currentTime(query=True)
+    try:
+        yield
+    finally:
+        cmds.currentTime(ct, edit=True)
+
+
+def memodict(f):
+    """Memoization decorator for a function taking a single argument.
+
+    See: http://code.activestate.com/recipes/
+         578231-probably-the-fastest-memoization-decorator-in-the-/
+    """
+
+    class memodict(dict):
+        def __missing__(self, key):
+            ret = self[key] = f(key)
+            return ret
+
+    return memodict().__getitem__
+
+
+def get_visible_in_frame_range(nodes, start, end):
+    """Return nodes that are visible in start-end frame range.
+
+    - Ignores intermediateObjects completely.
+    - Considers animated visibility attributes + upstream visibilities.
+
+    This is optimized for large scenes where some nodes in the parent
+    hierarchy might have some input connections to the visibilities,
+    e.g. key, driven keys, connections to other attributes, etc.
+
+    This only does a single time step to `start` if current frame is
+    not inside frame range since the assumption is made that changing
+    a frame isn't so slow that it beats querying all visibility
+    plugs through MDGContext on another frame.
+
+    Args:
+        nodes (list): List of node names to consider.
+        start (int): Start frame.
+        end (int): End frame.
+
+    Returns:
+        list: List of node names. These will be long full path names so
+            might have a longer name than the input nodes.
+
+    """
+    # States we consider per node
+    VISIBLE = 1  # always visible
+    INVISIBLE = 0  # always invisible
+    ANIMATED = -1  # animated visibility
+
+    # Ensure integers
+    start = int(start)
+    end = int(end)
+
+    # Consider only non-intermediate dag nodes and use the "long" names.
+    nodes = cmds.ls(nodes, long=True, noIntermediate=True, type="dagNode")
+    if not nodes:
+        return []
+
+    with maintained_time():
+        # Go to first frame of the range if we current time is outside of
+        # the queried range. This is to do a single query on which are at
+        # least visible at a time inside the range, (e.g those that are
+        # always visible)
+        current_time = cmds.currentTime(query=True)
+        if not (start <= current_time <= end):
+            cmds.currentTime(start)
+
+        visible = cmds.ls(nodes, long=True, visible=True)
+        if len(visible) == len(nodes) or start == end:
+            # All are visible on frame one, so they are at least visible once
+            # inside the frame range.
+            return visible
+
+    # For the invisible ones check whether its visibility and/or
+    # any of its parents visibility attributes are animated. If so, it might
+    # get visible on other frames in the range.
+    @memodict
+    def get_state(node):
+        plug = node + ".visibility"
+        connections = cmds.listConnections(plug,
+                                           source=True,
+                                           destination=False)
+        if connections:
+            return ANIMATED
+        else:
+            return VISIBLE if cmds.getAttr(plug) else INVISIBLE
+
+    visible = set(visible)
+    invisible = [node for node in nodes if node not in visible]
+    always_invisible = set()
+    # Iterate over the nodes by short to long names, so we iterate the highest
+    # in hierarcy nodes first. So the collected data can be used from the
+    # cache for parent queries in next iterations.
+    node_dependencies = dict()
+    for node in sorted(invisible, key=len):
+
+        state = get_state(node)
+        if state == INVISIBLE:
+            always_invisible.add(node)
+            continue
+
+        # If not always invisible by itself we should go through and check
+        # the parents to see if any of them are always invisible. For those
+        # that are "ANIMATED" we consider that this node is dependent on
+        # that attribute, we store them as dependency.
+        dependencies = set()
+        if state == ANIMATED:
+            dependencies.add(node)
+
+        traversed_parents = list()
+        for parent in iter_parents(node):
+
+            if not parent:
+                # Workaround bug in iter_parents
+                continue
+
+            if parent in always_invisible or get_state(parent) == INVISIBLE:
+                # When parent is always invisible then consider this parent,
+                # this node we started from and any of the parents we
+                # have traversed in-between to be *always invisible*
+                always_invisible.add(parent)
+                always_invisible.add(node)
+                always_invisible.update(traversed_parents)
+                break
+
+            # If we have traversed the parent before and its visibility
+            # was dependent on animated visibilities then we can just extend
+            # its dependencies for to those for this node and break further
+            # iteration upwards.
+            parent_dependencies = node_dependencies.get(parent, None)
+            if parent_dependencies is not None:
+                dependencies.update(parent_dependencies)
+                break
+
+            state = get_state(parent)
+            if state == ANIMATED:
+                dependencies.add(parent)
+
+            traversed_parents.append(parent)
+
+        if node not in always_invisible and dependencies:
+            node_dependencies[node] = dependencies
+
+    if not node_dependencies:
+        return list(visible)
+
+    # Now we only have to check the visibilities for nodes that have animated
+    # visibility dependencies upstream. The fastest way to check these
+    # visibility attributes across different frames is with Python api 2.0
+    # so we do that.
+    @memodict
+    def get_visibility_mplug(node):
+        """Return api 2.0 MPlug with cached memoize decorator"""
+        sel = om.MSelectionList()
+        sel.add(node)
+        dag = sel.getDagPath(0)
+        return om.MFnDagNode(dag).findPlug("visibility", True)
+
+    # We skip the first frame as we already used that frame to check for
+    # overall visibilities. And end+1 to include the end frame.
+    scene_units = om.MTime.uiUnit()
+    for frame in range(start + 1, end + 1):
+
+        mtime = om.MTime(frame, unit=scene_units)
+        context = om.MDGContext(mtime)
+
+        # Build little cache so we don't query the same MPlug's value
+        # again if it was checked on this frame and also is a dependency
+        # for another node
+        frame_visibilities = {}
+
+        for node, dependencies in node_dependencies.items():
+
+            for dependency in dependencies:
+
+                dependency_visible = frame_visibilities.get(dependency, None)
+                if dependency_visible is None:
+                    mplug = get_visibility_mplug(dependency)
+                    dependency_visible = mplug.asBool(context)
+                    frame_visibilities[dependency] = dependency_visible
+
+                if not dependency_visible:
+                    # One dependency is not visible, thus the
+                    # node is not visible.
+                    break
+
+            else:
+                # All dependencies are visible.
+                visible.add(node)
+                # Remove node with dependencies for next iterations
+                # because it was visible at least once.
+                node_dependencies.pop(node)
+
+        # If no more nodes to process break the frame iterations..
+        if not node_dependencies:
+            break
+
+    return list(visible)

--- a/colorbleed/plugins/maya/create/colorbleed_animation.py
+++ b/colorbleed/plugins/maya/create/colorbleed_animation.py
@@ -29,6 +29,10 @@ class CreateAnimation(avalon.maya.Creator):
         # frame range.
         self.data["visibleOnly"] = False
 
+        # Include a more thorough check to ensure only nodes that are
+        # are at least visible once throughout the frame range are included
+        self.data["visibleOnlyInFrameRange"] = False
+
         # Include the groups above the out_SET content
         self.data["includeParentHierarchy"] = False  # Include parent groups
 

--- a/colorbleed/plugins/maya/create/colorbleed_pointcache.py
+++ b/colorbleed/plugins/maya/create/colorbleed_pointcache.py
@@ -18,6 +18,11 @@ class CreatePointCache(avalon.maya.Creator):
         self.data["writeColorSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
         self.data["visibleOnly"] = False     # only nodes that are visible
+
+        # Include a more thorough check to ensure only nodes that are
+        # are at least visible once throughout the frame range are included
+        self.data["visibleOnlyInFrameRange"] = False
+
         self.data["includeParentHierarchy"] = False  # Include parent groups
         self.data["worldSpace"] = True       # Default to exporting world-space
 

--- a/colorbleed/plugins/maya/publish/extract_animation.py
+++ b/colorbleed/plugins/maya/publish/extract_animation.py
@@ -4,7 +4,7 @@ from maya import cmds
 
 import avalon.maya
 import colorbleed.api
-from colorbleed.maya.lib import extract_alembic
+from colorbleed.maya.lib import extract_alembic, get_visible_in_frame_range
 
 
 class ExtractColorbleedAnimation(colorbleed.api.Extractor):
@@ -70,6 +70,16 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
         if int(cmds.about(version=True)) >= 2017:
             # Since Maya 2017 alembic supports multiple uv sets - write them.
             options["writeUVSets"] = True
+
+        if instance.data.get("visibleOnlyInFrameRange", False):
+            # If we only want to include nodes that are visible in the frame
+            # range then we need to do our own check. Alembic's `visibleOnly`
+            # flag does not filter out those that are only hidden on some
+            # frames as it counts "animated" or "connected" visibilities as
+            # if it's always visible.
+            nodes = get_visible_in_frame_range(nodes,
+                                               start=start,
+                                               end=end)
 
         with avalon.maya.suspended_refresh():
             with avalon.maya.maintained_selection():

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -4,7 +4,7 @@ from maya import cmds
 
 import avalon.maya
 import colorbleed.api
-from colorbleed.maya.lib import extract_alembic
+from colorbleed.maya.lib import extract_alembic, get_visible_in_frame_range
 
 
 class ExtractColorbleedAlembic(colorbleed.api.Extractor):
@@ -70,6 +70,16 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
         if int(cmds.about(version=True)) >= 2017:
             # Since Maya 2017 alembic supports multiple uv sets - write them.
             options["writeUVSets"] = True
+
+        if instance.data.get("visibleOnlyInFrameRange", False):
+            # If we only want to include nodes that are visible in the frame
+            # range then we need to do our own check. Alembic's `visibleOnly`
+            # flag does not filter out those that are only hidden on some
+            # frames as it counts "animated" or "connected" visibilities as
+            # if it's always visible.
+            nodes = get_visible_in_frame_range(nodes,
+                                               start=start,
+                                               end=end)
 
         with avalon.maya.suspended_refresh():
             with avalon.maya.maintained_selection():

--- a/colorbleed/plugins/maya/publish/extract_quicktime.py
+++ b/colorbleed/plugins/maya/publish/extract_quicktime.py
@@ -1,13 +1,11 @@
 import os
 import errno
-import subprocess
-import contextlib
-import json
 
 import avalon.maya
 from avalon.vendor import clique
 
 import colorbleed.api
+from colorbleed.maya.lib import maintained_time
 
 from maya import cmds, mel
 import capture_gui.lib
@@ -210,12 +208,3 @@ class ExtractQuicktime(colorbleed.api.Extractor):
         # Store both the version without burnin and with burnin
         instance.data["files"].append(movie_file)
         instance.data["files"].append(movie_file_burnin)
-
-
-@contextlib.contextmanager
-def maintained_time():
-    ct = cmds.currentTime(query=True)
-    try:
-        yield
-    finally:
-        cmds.currentTime(ct, edit=True)


### PR DESCRIPTION
This contains two optimations:
- Optimizations: allow excluding animated visible meshes for alembic if never visible 
- Discard intermediate playblast files after encoding

Regarding the alembic visibilities:

### Implement `visibleOnlyInFrameRange` for animated Alembic exports.

- This will run a more thorough check than the normal `visibleOnly` flag
  that is present in Alembic exports. This thorough check will contain
  solely dag nodes that are visible at least once during the frame range
  whereas Alembic's `visibleOnly` will alway see nodes with a connection
  to the visibility attribute, like keys, to be "potentially visible"
- Plus cleaned up extract_quicktime and put the "maintained_time" in
  colorbleed.maya.lib as it was reused.