### PR TITLE
Optimizations: avoid always importing pymel for publishing plug-ins & exclude constraints in Alembic caches

### DIFF
--- a/colorbleed/plugins/maya/publish/extract_animation.py
+++ b/colorbleed/plugins/maya/publish/extract_animation.py
@@ -34,6 +34,12 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
                                            allDescendents=True,
                                            fullPath=True) or []
 
+        # Exclude constraint nodes as they are useless data in the export.
+        # Somehow ls(excludeType) does not seem to work, so filter manually.
+        exclude = set(cmds.ls(nodes, type="constraint", long=True))
+        if exclude:
+            nodes = [node for node in nodes if node not in exclude]
+
         # Collect the start and end including handles
         start = instance.data["startFrame"]
         end = instance.data["endFrame"]

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -24,6 +24,12 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
 
         nodes = instance[:]
 
+        # Exclude constraint nodes as they are useless data in the export.
+        # Somehow ls(excludeType) does not seem to work, so filter manually.
+        exclude = set(cmds.ls(nodes, type="constraint", long=True))
+        if exclude:
+            nodes = [node for node in nodes if node not in exclude]
+
         # Collect the start and end including handles
         start = instance.data.get("startFrame", 1)
         end = instance.data.get("endFrame", 1)

--- a/colorbleed/plugins/maya/publish/validate_no_namespace.py
+++ b/colorbleed/plugins/maya/publish/validate_no_namespace.py
@@ -1,4 +1,3 @@
-import pymel.core as pm
 import maya.cmds as cmds
 
 import pyblish.api
@@ -40,6 +39,11 @@ class ValidateNoNamespace(pyblish.api.InstancePlugin):
     @classmethod
     def repair(cls, instance):
         """Remove all namespaces from the nodes in the instance"""
+
+        # Only import pymel when we actually need it for repair
+        # since it's slow to initialize (this is only plug-in that
+        # needed it).
+        import pymel.core as pm
 
         invalid = cls.get_invalid(instance)
 


### PR DESCRIPTION
Optimizations: 

- avoid always importing pymel for publishing plug-ins 
- exclude constraints in Alembic cache outputs for animation+pointcache families