### PR TITLE
Add backwards compatibility and remove "visibleOnlyInFrameRange"

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_animation.py
+++ b/colorbleed/plugins/maya/create/colorbleed_animation.py
@@ -29,10 +29,6 @@ class CreateAnimation(avalon.maya.Creator):
         # frame range.
         self.data["visibleOnly"] = False
 
-        # Include a more thorough check to ensure only nodes that are
-        # are at least visible once throughout the frame range are included
-        self.data["visibleOnlyInFrameRange"] = False
-
         # Include the groups above the out_SET content
         self.data["includeParentHierarchy"] = False  # Include parent groups
 

--- a/colorbleed/plugins/maya/create/colorbleed_pointcache.py
+++ b/colorbleed/plugins/maya/create/colorbleed_pointcache.py
@@ -17,11 +17,10 @@ class CreatePointCache(avalon.maya.Creator):
 
         self.data["writeColorSets"] = False  # Vertex colors with the geometry.
         self.data["renderableOnly"] = False  # Only renderable visible shapes
-        self.data["visibleOnly"] = False     # only nodes that are visible
 
         # Include a more thorough check to ensure only nodes that are
         # are at least visible once throughout the frame range are included
-        self.data["visibleOnlyInFrameRange"] = False
+        self.data["visibleOnly"] = False
 
         self.data["includeParentHierarchy"] = False  # Include parent groups
         self.data["worldSpace"] = True       # Default to exporting world-space

--- a/colorbleed/plugins/maya/publish/collect_renderlayer_custom_framelist.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayer_custom_framelist.py
@@ -87,6 +87,14 @@ class CollectRenderlayerCustomFramelist(pyblish.api.InstancePlugin):
         # Get the renderlayer for this instance
         layer = instance.data["setMembers"]
 
+        # Backwards compatibility for older instances
+        if not cmds.attributeQuery("userCustomFrameList",
+                                   node=node,
+                                   exists=True):
+            self.log.info("Old renderglobalsDefault instance detected without "
+                          "`useCustomFrameList` attribute. Ignoring..")
+            return
+
         # Get settings from renderGlobalsDefault node in that layer
         use_frame_list = lib.get_attr_in_layer(node + ".useCustomFrameList",
                                                layer=layer)

--- a/colorbleed/plugins/maya/publish/extract_animation.py
+++ b/colorbleed/plugins/maya/publish/extract_animation.py
@@ -77,7 +77,11 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
             # Since Maya 2017 alembic supports multiple uv sets - write them.
             options["writeUVSets"] = True
 
-        if instance.data.get("visibleOnlyInFrameRange", False):
+        visible_in_frame_range_only = instance.data.get(
+            "visibleOnlyInFrameRange",  # Backwards compatibility
+            instance.data.get("visibleOnly", False)
+        )
+        if visible_in_frame_range_only:
             # If we only want to include nodes that are visible in the frame
             # range then we need to do our own check. Alembic's `visibleOnly`
             # flag does not filter out those that are only hidden on some

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -77,7 +77,11 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
             # Since Maya 2017 alembic supports multiple uv sets - write them.
             options["writeUVSets"] = True
 
-        if instance.data.get("visibleOnlyInFrameRange", False):
+        visible_in_frame_range_only = instance.data.get(
+            "visibleOnlyInFrameRange",  # Backwards compatibility
+            instance.data.get("visibleOnly", False)
+        )
+        if visible_in_frame_range_only:
             # If we only want to include nodes that are visible in the frame
             # range then we need to do our own check. Alembic's `visibleOnly`
             # flag does not filter out those that are only hidden on some


### PR DESCRIPTION
- Fix backwards compatibility for older `renderglobalsDefault` instances on `useCustomFrameList`.
- Remove `visibleOnlyInFrameRange` in favor of `visibleOnly` as that did nothing before and was intended to be used for exactly this behavior. This fixes it, while maintaining backwards compatibility for the instances that still have the `visibleOnlyInFrameRange` attribute.