### PR TITLE
Implement Houdini Remote Publish + improve version detection Fusion switch shot

### DIFF
--- a/colorbleed/houdini/__init__.py
+++ b/colorbleed/houdini/__init__.py
@@ -71,6 +71,10 @@ def on_save(*args):
 
 def on_open(*args):
 
+    if not hou.isUIAvailable():
+        log.debug("Batch mode detected, ignoring `on_open` callbacks..")
+        return
+
     avalon.logger.info("Running callback on open..")
 
     update_task_from_path(hou.hipFile.path())

--- a/colorbleed/plugins/houdini/publish/extract_alembic.py
+++ b/colorbleed/plugins/houdini/publish/extract_alembic.py
@@ -9,6 +9,7 @@ class ExtractAlembic(colorbleed.api.Extractor):
     order = pyblish.api.ExtractorOrder
     label = "Extract Alembic"
     hosts = ["houdini"]
+    targets = ["local"]
     families = ["colorbleed.pointcache", "colorbleed.camera"]
 
     def process(self, instance):
@@ -27,8 +28,13 @@ class ExtractAlembic(colorbleed.api.Extractor):
         # We run the render
         self.log.info("Writing alembic '%s' to '%s'" % (file_name,
                                                         staging_dir))
+
+        # Print verbose when in batch mode without UI
+        verbose = not hou.isUIAvailable()
+
+        # Render
         try:
-            ropnode.render()
+            ropnode.render(verbose=verbose)
         except hou.Error as exc:
             # The hou.Error is not inherited from a Python Exception class,
             # so we explicitly capture the houdini error, otherwise pyblish

--- a/colorbleed/plugins/houdini/publish/extract_composite.py
+++ b/colorbleed/plugins/houdini/publish/extract_composite.py
@@ -9,6 +9,7 @@ class ExtractComposite(colorbleed.api.Extractor):
     order = pyblish.api.ExtractorOrder
     label = "Extract Composite (Image Sequence)"
     hosts = ["houdini"]
+    targets = ["local"]
     families = ["colorbleed.imagesequence"]
 
     def process(self, instance):
@@ -25,10 +26,13 @@ class ExtractComposite(colorbleed.api.Extractor):
         file_name = os.path.basename(output)
 
         self.log.info("Writing comp '%s' to '%s'" % (file_name, staging_dir))
-        
+
+        # Print verbose when in batch mode without UI
+        verbose = not hou.isUIAvailable()
+
         # Render
         try:
-            ropnode.render()
+            ropnode.render(verbose=verbose)
         except hou.Error as exc:
             # The hou.Error is not inherited from a Python Exception class,
             # so we explicitly capture the houdini error, otherwise pyblish

--- a/colorbleed/plugins/houdini/publish/extract_vdb_cache.py
+++ b/colorbleed/plugins/houdini/publish/extract_vdb_cache.py
@@ -9,6 +9,7 @@ class ExtractVDBCache(colorbleed.api.Extractor):
     order = pyblish.api.ExtractorOrder + 0.1
     label = "Extract VDB Cache"
     families = ["colorbleed.vdbcache"]
+    targets = ["local"]
     hosts = ["houdini"]
 
     def process(self, instance):
@@ -25,10 +26,13 @@ class ExtractVDBCache(colorbleed.api.Extractor):
         file_name = os.path.basename(sop_output)
 
         self.log.info("Writing VDB '%s' to '%s'" % (file_name, staging_dir))
-        
+
+        # Print verbose when in batch mode without UI
+        verbose = not hou.isUIAvailable()
+
         # Render
         try:
-            ropnode.render()
+            ropnode.render(verbose=verbose)
         except hou.Error as exc:
             # The hou.Error is not inherited from a Python Exception class,
             # so we explicitly capture the houdini error, otherwise pyblish

--- a/colorbleed/plugins/houdini/publish/increment_current_file_deadline.py
+++ b/colorbleed/plugins/houdini/publish/increment_current_file_deadline.py
@@ -1,0 +1,34 @@
+import pyblish.api
+
+import os
+import hou
+from colorbleed.lib import version_up
+from colorbleed.action import get_errored_plugins_from_data
+
+
+class IncrementCurrentFileDeadline(pyblish.api.ContextPlugin):
+    """Increment the current file.
+
+    Saves the current scene with an increased version number.
+
+    """
+
+    label = "Increment current file"
+    order = pyblish.api.IntegratorOrder + 9.0
+    hosts = ["houdini"]
+    targets = ["deadline"]
+
+    def process(self, context):
+
+        errored_plugins = get_errored_plugins_from_data(context)
+        if any(plugin.__name__ == "HoudiniSubmitPublishDeadline"
+                for plugin in errored_plugins):
+            raise RuntimeError("Skipping incrementing current file because "
+                               "submission to deadline failed.")
+
+        current_filepath = context.data["currentFile"]
+        new_filepath = version_up(current_filepath)
+
+        hou.hipFile.save(file_name=new_filepath,
+                         save_to_recent_files=True)
+

--- a/colorbleed/plugins/houdini/publish/save_scene.py
+++ b/colorbleed/plugins/houdini/publish/save_scene.py
@@ -1,0 +1,23 @@
+import pyblish.api
+
+
+class SaveCurrentScene(pyblish.api.ContextPlugin):
+    """Save current scene"""
+
+    label = "Save current file"
+    order = pyblish.api.IntegratorOrder - 0.49
+    hosts = ["houdini"]
+    targets = ["deadline"]
+
+    def process(self, context):
+        import hou
+
+        assert context.data['currentFile'] == hou.hipFile.path(), (
+            "Collected filename from current scene name."
+        )
+
+        if hou.hipFile.hasUnsavedChanges():
+            self.log.info("Saving current file..")
+            hou.hipFile.save(save_to_recent_files=True)
+        else:
+            self.log.debug("No unsaved changes, skipping file save..")

--- a/colorbleed/plugins/houdini/publish/submit_remote_publish.py
+++ b/colorbleed/plugins/houdini/publish/submit_remote_publish.py
@@ -1,0 +1,126 @@
+import os
+import json
+import getpass
+
+import hou
+
+from avalon import api, io
+from avalon.vendor import requests
+
+import pyblish.api
+
+
+class HoudiniSubmitPublishDeadline(pyblish.api.ContextPlugin):
+    """Submit Houdini scene to perform a local publish in Deadline.
+
+    Publishing in Deadline can be helpful for scenes that publish very slow.
+    This way it can process in the background on another machine without the
+    Artist having to wait for the publish to finish on their local machine.
+
+    Submission is done through the Deadline Web Service as
+    supplied via the environment variable AVALON_DEADLINE.
+
+    """
+
+    label = "Submit Scene to Deadline"
+    order = pyblish.api.IntegratorOrder
+    hosts = ["houdini"]
+    families = ["*"]
+    targets = ["deadline"]
+
+    def process(self, context):
+
+        # Ensure no errors so far
+        assert all(result["success"] for result in context.data["results"]), (
+            "Errors found, aborting integration..")
+
+        # Deadline connection
+        AVALON_DEADLINE = api.Session.get("AVALON_DEADLINE",
+                                          "http://localhost:8082")
+        assert AVALON_DEADLINE, "Requires AVALON_DEADLINE"
+
+        # Note that `publish` data member might change in the future.
+        # See: https://github.com/pyblish/pyblish-base/issues/307
+        actives = [i for i in context if i.data["publish"]]
+        instance_names = sorted(instance.name for instance in actives)
+
+        if not instance_names:
+            self.log.warning("No active instances found. "
+                             "Skipping submission..")
+            return
+
+        scene = context.data["currentFile"]
+        scenename = os.path.basename(scene)
+
+        # Get project code
+        project = io.find_one({"type": "project"})
+        code = project["data"].get("code", project["name"])
+
+        job_name = "{scene} [PUBLISH]".format(scene=scenename)
+        batch_name = "{code} - {scene}".format(code=code, scene=scenename)
+        deadline_user = "roy"  # todo: get deadline user dynamically
+
+        # Get only major.minor version of Houdini, ignore patch version
+        version = hou.applicationVersionString()
+        version = ".".join(version.split(".")[:2])
+
+        # Generate the payload for Deadline submission
+        payload = {
+            "JobInfo": {
+                "Plugin": "Houdini",
+                "Pool": "houdini",  # todo: remove hardcoded pool
+                "BatchName": batch_name,
+                "Comment": context.data.get("comment", ""),
+                "Priority": 50,
+                "Frames": "1-1",    # Always trigger a single frame
+                "IsFrameDependent": False,
+                "Name": job_name,
+                "UserName": deadline_user,
+                # "Comment": instance.context.data.get("comment", ""),
+                # "InitialStatus": state
+
+            },
+            "PluginInfo": {
+
+                "Build": None,  # Don't force build
+                "IgnoreInputs": True,
+
+                # Inputs
+                "SceneFile": scene,
+                "OutputDriver": "/out/REMOTE_PUBLISH",
+
+                # Mandatory for Deadline
+                "Version": version,
+
+            },
+
+            # Mandatory for Deadline, may be empty
+            "AuxFiles": []
+        }
+
+        # Include critical environment variables with submission + api.Session
+        keys = [
+            # Submit along the current Avalon tool setup that we launched
+            # this application with so the Render Slave can build its own
+            # similar environment using it, e.g. "houdini17.5;pluginx2.3"
+            "AVALON_TOOLS",
+        ]
+        environment = dict({key: os.environ[key] for key in keys
+                            if key in os.environ}, **api.Session)
+        environment["PYBLISH_ACTIVE_INSTANCES"] = ",".join(instance_names)
+
+        payload["JobInfo"].update({
+            "EnvironmentKeyValue%d" % index: "{key}={value}".format(
+                key=key,
+                value=environment[key]
+            ) for index, key in enumerate(environment)
+        })
+
+        self.log.info("Submitting..")
+        self.log.info(json.dumps(payload, indent=4, sort_keys=True))
+
+        # E.g. http://192.168.0.1:8082/api/jobs
+        url = "{}/api/jobs".format(AVALON_DEADLINE)
+        response = requests.post(url, json=payload)
+        if not response.ok:
+            raise Exception(response.text)

--- a/colorbleed/plugins/houdini/publish/validate_remote_publish.py
+++ b/colorbleed/plugins/houdini/publish/validate_remote_publish.py
@@ -1,0 +1,78 @@
+import pyblish.api
+import colorbleed.api
+
+import hou
+
+
+class ValidateRemotePublishOutNode(pyblish.api.InstancePlugin):
+    """Validate the remote publish out node exists for Deadline to trigger."""
+
+    order = colorbleed.api.ValidateContentsOrder - 0.4
+    families = ["*"]
+    hosts = ['houdini']
+    targets = ["deadline"]
+    label = 'Remote Publish ROP node'
+    actions = [colorbleed.api.RepairAction]
+
+    cmd = "import pyblish.util; pyblish.util.publish()"
+
+    def process(self, instance):
+
+        # todo: refactor to context plugin
+
+        node = hou.node("/out/REMOTE_PUBLISH")
+        if not node:
+            raise RuntimeError("Missing REMOTE_PUBLISH node.")
+
+        # We ensure it's a shell node and that it has the pre-render script
+        # set correctly. Plus the shell script it will trigger should be
+        # completely empty (doing nothing)
+        assert node.type().name() == "shell", "Must be shell ROP node"
+        assert node.parm("command").eval() == "", "Must have no command"
+        assert not node.parm("shellexec").eval(), "Must not execute in shell"
+        assert node.parm("prerender").eval() == self.cmd, (
+            "REMOTE_PUBLISH node does not have correct prerender script."
+        )
+        assert node.parm("lprerender").eval() == "python", (
+            "REMOTE_PUBLISH node prerender script type not set to 'python'"
+        )
+
+    @classmethod
+    def repair(cls, instance):
+        """(Re)create the node if it fails to pass validation"""
+
+        existing = hou.node("/out/REMOTE_PUBLISH")
+        if existing:
+            cls.log.warning("Removing existing '/out/REMOTE_PUBLISH' node..")
+            existing.destroy()
+
+        # Create the shell node
+        out = hou.node("/out")
+        shell = out.createNode("shell", node_name="REMOTE_PUBLISH")
+        shell.moveToGoodPosition()
+
+        # Set the pre-render script
+        shell.setParms({
+            "prerender": cls.cmd,
+            "lprerender": "python"  # command language
+        })
+
+        # Lock the attributes to ensure artists won't easily mess things up.
+        shell.parm("prerender").lock(True)
+        shell.parm("lprerender").lock(True)
+
+        # Lock up the actual shell command
+        command_parm = shell.parm("command")
+        command_parm.set("")
+        command_parm.lock(True)
+        command_parm.hide(True)
+        shellexec_parm = shell.parm("shellexec")
+        shellexec_parm.set(False)
+        shellexec_parm.lock(True)
+        shellexec_parm.hide(True)
+
+        # Tweak the node's template so it's a lot clearer to the artist.
+        # todo: Hide the Shell tab itself (python code below still shows tab)
+        # template = node.parmTemplateGroup()
+        # template.hideFolder("Shell", True)
+        # node.setParmTemplateGroup(template)

--- a/colorbleed/scripts/fusion_switch_shot.py
+++ b/colorbleed/scripts/fusion_switch_shot.py
@@ -139,23 +139,19 @@ def _update_savers(comp, session):
 
             else:
                 # Else reuse the relative path
-                # Reset version folders in the relative path to v001
-                version_folder_pattern = r"/v[0-9]+/"
-                if re.search(version_folder_pattern, relpath):
-                    new_relpath = re.sub(version_folder_pattern,
-                                         "/v001/",
+                # Reset version in folder and filename in the relative path
+                # to v001. The version should be is only detected when prefixed
+                # with either `_v` (underscore) or `/v` (folder)
+                version_pattern = r"(/|_)v[0-9]+"
+                if re.search(version_pattern, relpath):
+                    new_relpath = re.sub(version_pattern,
+                                         r"\1v001",
                                          relpath)
                     log.info("Resetting version folders to v001: "
                              "%s -> %s" % (relpath, new_relpath))
                     relpath = new_relpath
 
                 new_path = os.path.join(new_work, relpath)
-
-                # Reset version in filename
-                # Version must be prefixed with `_v`
-                filename = os.path.basename(new_path)
-                filename = re.sub("_v[0-9]+", "_v001", filename)
-                new_path = os.path.join(os.path.dirname(new_path), filename)
 
             saver["Clip"] = new_path
 


### PR DESCRIPTION
### Publish Houdini scene remotely in Deadline on a render node.

This implements remote publishing on the farm in Deadline for Houdini.

There's no menu item yet, however you can trigger this from a Shelf Script in Houdini to submit a publish job on the farm:
```python
import pyblish_qml

parent = hou.qt.mainWindow()
pyblish_qml.show(parent, targets=["default", "deadline"])
```

_Do **not** trigger it from Python shell in Houdini as that will fail to run the Qt processes in the background._

#### How to:

1. Right click on your shelf -> `New Tool...`
2. Paste in the above script + make sure language is set to `python`
3. In the Options tab you can rename the label to `Publish Remote`.
4. Click Accept.
5. Click the "Publish Remote" button. 🥇 

#### Special Remote Publish validator that you'll need to "repair" first time.

There is a special validator that *on repair* creates the required `/out/REMOTE_PUBLISH`  node that allows Deadline to correctly publish it on the farm. This works in regular batch mode in Houdini, and as such also works with Houdini Engine licenses.

---

### Improve Switch Shot tool to preserve saver output paths on switching

This improves "versioning" of the saver files on switching shots for Fusion comps with the *Switch Shot* tool where it preserves the relative path from the previous shot to the `/fusion` folder. It's a bit magical, but eh, artist request.

