### PR TITLE
Houdini Remote Publish allow to submit as separate job per instance

### DIFF
--- a/colorbleed/houdini/lib.py
+++ b/colorbleed/houdini/lib.py
@@ -1,13 +1,14 @@
 import uuid
-
+import logging
 from contextlib import contextmanager
+
+from colorbleed import lib
+from avalon import api, io
+from avalon.houdini import lib as houdini
 
 import hou
 
-from colorbleed import lib
-
-from avalon import api, io
-from avalon.houdini import lib as houdini
+log = logging.getLogger(__name__)
 
 
 def set_id(node, unique_id, overwrite=False):
@@ -232,3 +233,82 @@ def validate_fps():
             return False
 
     return True
+
+
+def create_remote_publish_node(force=True):
+    """Function to create a remote publish node in /out
+
+    This is a hacked "Shell" node that does *nothing* except for triggering
+    `pyblish.util.publish()` as pre-render script. All default attributes of
+    the Shell node are hidden to the Artist to avoid confusion.
+
+    Additionally some custom attributes are added that can be collected
+    by a Collector to set specific settings for the publish, e.g. whether
+    to separate the jobs per instance or process in one single job.
+
+    """
+
+    cmd = "import pyblish.util; pyblish.util.publish()"
+
+    existing = hou.node("/out/REMOTE_PUBLISH")
+    if existing:
+        if force:
+            log.warning("Removing existing '/out/REMOTE_PUBLISH' node..")
+            existing.destroy()
+        else:
+            raise RuntimeError("Node already exists /out/REMOTE_PUBLISH. "
+                               "Please remove manually or set `force` to "
+                               "True.")
+
+    # Create the shell node
+    out = hou.node("/out")
+    node = out.createNode("shell", node_name="REMOTE_PUBLISH")
+    node.moveToGoodPosition()
+
+    # Set the pre-render script
+    node.setParms({
+        "prerender": cmd,
+        "lprerender": "python"  # command language
+    })
+
+    # Lock the attributes to ensure artists won't easily mess things up.
+    node.parm("prerender").lock(True)
+    node.parm("lprerender").lock(True)
+
+    # Lock up the actual shell command
+    command_parm = node.parm("command")
+    command_parm.set("")
+    command_parm.lock(True)
+    shellexec_parm = node.parm("shellexec")
+    shellexec_parm.set(False)
+    shellexec_parm.lock(True)
+
+    # Get the node's parm template group so we can customize it
+    template = node.parmTemplateGroup()
+
+    # Hide default tabs
+    template.hideFolder("Shell", True)
+    template.hideFolder("Scripts", True)
+
+    # Hide default settings
+    template.hide("execute", True)
+    template.hide("renderdialog", True)
+    template.hide("trange", True)
+    template.hide("f", True)
+    template.hide("take", True)
+
+    # Add custom settings to this node.
+    parm_folder = hou.FolderParmTemplate("folder", "Submission Settings")
+
+    # Separate Jobs per Instance
+    parm = hou.ToggleParmTemplate(name="separateJobPerInstance",
+                                  label="Separate Job per Instance",
+                                  default_value=False)
+    parm_folder.addParmTemplate(parm)
+
+    # Add our custom Submission Settings folder
+    template.append(parm_folder)
+
+    # Apply template back to the node
+    node.setParmTemplateGroup(template)
+

--- a/colorbleed/plugins/global/publish/collect_pyblish_active_instances.py
+++ b/colorbleed/plugins/global/publish/collect_pyblish_active_instances.py
@@ -1,0 +1,65 @@
+import os
+import pyblish.api
+
+
+class CollectInstancesActiveState(pyblish.api.ContextPlugin):
+    """Collect instance active state from PYBLISH_ACTIVE_INSTANCES.
+
+    This will read the PYBLISH_ACTIVE_INSTANCES environment variable and split
+    the string by comma. Only those instances that match by name with the
+    entries in that list will remain active for publishing, the rest will
+    be deactivated.
+
+    This is used for activating solely those instances that are set in the
+    environment variable, which is used for Deadline farm jobs that trigger
+    Pyblish publishes on the farm and we want to ensure only specific
+    instances are processed.
+
+    """
+    targets = ["local"]
+    order = pyblish.api.CollectorOrder + 0.499
+    label = "Force Instances Active State"
+
+    def process(self, context):
+
+        active = os.environ.get("PYBLISH_ACTIVE_INSTANCES")
+        if active is None:
+            # The value is not set in the environment so we ignore this
+            # collector completely
+            self.log.debug("PYBLISH_ACTIVE_INSTANCES not set. "
+                           "Ignoring collector..")
+            return
+
+        if not active:
+            raise RuntimeError("No registered active instances to process"
+                               " in PYBLISH_ACTIVE_INSTANCES.")
+
+        # Make set of valid entries, split by comma
+        active = set(name.strip() for name in active.split(",") if
+                     name.strip())
+
+        found = set()
+        for instance in context:
+
+            # Set the state per instance
+            state = instance.name in active
+            self.log.info("Setting %s publish state to %s" % (instance.name,
+                                                              state))
+            instance.data["active"] = state
+            instance.data["publish"] = state
+
+            if state:
+                found.add(instance.name)
+
+        # Ensure all PYBLISH_ACTIVE_INSTANCES are found so that we can
+        # expect the publish to be consistent with what the user requested
+        missing = active - found
+        if missing:
+            raise RuntimeError("Missing subsets: %s" % list(missing))
+
+
+# Avoid this plug-in all together when PYBLISH_ACTIVE_INSTANCES is not set so
+# we only ever load this whenever that environment variable is set at the time
+# of discovering Pyblish plug-ins.
+if "PYBLISH_ACTIVE_INSTANCES" not in os.environ:
+    del CollectInstancesActiveState

--- a/colorbleed/plugins/houdini/create/create_remote_publish.py
+++ b/colorbleed/plugins/houdini/create/create_remote_publish.py
@@ -1,0 +1,22 @@
+from avalon import houdini
+
+from colorbleed.houdini import lib
+
+
+class CreateRemotePublish(houdini.Creator):
+    """Create Remote Publish Submission Settings node."""
+
+    label = "Remote Publish"
+    family = "remotePublish"
+    icon = "cloud-upload"
+
+    def process(self):
+        """This is a stub creator process.
+
+         This does not create a regular instance that the instance collector
+         picks up. Instead we force this one to solely create something we
+         explicitly want to create. The only reason this class is here is so
+         that Artists can also create the node through the Avalon creator.
+
+         """
+        lib.create_remote_publish_node(force=True)

--- a/colorbleed/plugins/houdini/publish/collect_inputs.py
+++ b/colorbleed/plugins/houdini/publish/collect_inputs.py
@@ -99,6 +99,13 @@ class CollectUpstreamInputs(pyblish.api.InstancePlugin):
         # and include that together with its ancestors
         output = instance.data["output_node"]
 
+        if output is None:
+            # If no valid output node is set then ignore it as validation
+            # will be checking those cases.
+            self.log.debug("No output node found, skipping "
+                           "collecting of inputs..")
+            return
+
         # Collect all upstream parents
         nodes = list(iter_upstream(output))
         nodes.append(output)

--- a/colorbleed/plugins/houdini/publish/collect_remote_publish.py
+++ b/colorbleed/plugins/houdini/publish/collect_remote_publish.py
@@ -1,0 +1,30 @@
+import pyblish.api
+import colorbleed.api
+
+import hou
+from avalon.houdini import lib
+
+
+class CollectRemotePublishSettings(pyblish.api.ContextPlugin):
+    """Collect custom settings of the Remote Publish node."""
+
+    order = pyblish.api.CollectorOrder
+    families = ["*"]
+    hosts = ['houdini']
+    targets = ["deadline"]
+    label = 'Remote Publish Submission Settings'
+    actions = [colorbleed.api.RepairAction]
+
+    def process(self, context):
+
+        node = hou.node("/out/REMOTE_PUBLISH")
+        if not node:
+            return
+
+        attributes = lib.read(node)
+
+        # Debug the settings we have collected
+        for key, value in sorted(attributes.items()):
+            self.log.debug("Collected %s: %s" % (key, value))
+
+        context.data.update(attributes)

--- a/colorbleed/plugins/houdini/publish/extract_alembic.py
+++ b/colorbleed/plugins/houdini/publish/extract_alembic.py
@@ -34,7 +34,9 @@ class ExtractAlembic(colorbleed.api.Extractor):
 
         # Render
         try:
-            ropnode.render(verbose=verbose)
+            ropnode.render(verbose=verbose,
+                           # Allow Deadline to capture completion percentage
+                           output_progress=verbose)
         except hou.Error as exc:
             # The hou.Error is not inherited from a Python Exception class,
             # so we explicitly capture the houdini error, otherwise pyblish

--- a/colorbleed/plugins/houdini/publish/extract_composite.py
+++ b/colorbleed/plugins/houdini/publish/extract_composite.py
@@ -32,7 +32,9 @@ class ExtractComposite(colorbleed.api.Extractor):
 
         # Render
         try:
-            ropnode.render(verbose=verbose)
+            ropnode.render(verbose=verbose,
+                           # Allow Deadline to capture completion percentage
+                           output_progress=verbose)
         except hou.Error as exc:
             # The hou.Error is not inherited from a Python Exception class,
             # so we explicitly capture the houdini error, otherwise pyblish

--- a/colorbleed/plugins/houdini/publish/extract_vdb_cache.py
+++ b/colorbleed/plugins/houdini/publish/extract_vdb_cache.py
@@ -32,7 +32,9 @@ class ExtractVDBCache(colorbleed.api.Extractor):
 
         # Render
         try:
-            ropnode.render(verbose=verbose)
+            ropnode.render(verbose=verbose,
+                           # Allow Deadline to capture completion percentage
+                           output_progress=verbose)
         except hou.Error as exc:
             # The hou.Error is not inherited from a Python Exception class,
             # so we explicitly capture the houdini error, otherwise pyblish

--- a/colorbleed/plugins/houdini/publish/validate_remote_publish.py
+++ b/colorbleed/plugins/houdini/publish/validate_remote_publish.py
@@ -1,10 +1,12 @@
 import pyblish.api
 import colorbleed.api
 
+from colorbleed.houdini import lib
+
 import hou
 
 
-class ValidateRemotePublishOutNode(pyblish.api.InstancePlugin):
+class ValidateRemotePublishOutNode(pyblish.api.ContextPlugin):
     """Validate the remote publish out node exists for Deadline to trigger."""
 
     order = colorbleed.api.ValidateContentsOrder - 0.4
@@ -12,13 +14,11 @@ class ValidateRemotePublishOutNode(pyblish.api.InstancePlugin):
     hosts = ['houdini']
     targets = ["deadline"]
     label = 'Remote Publish ROP node'
-    actions = [colorbleed.api.RepairAction]
+    actions = [colorbleed.api.RepairContextAction]
 
-    cmd = "import pyblish.util; pyblish.util.publish()"
+    def process(self, context):
 
-    def process(self, instance):
-
-        # todo: refactor to context plugin
+        cmd = "import pyblish.util; pyblish.util.publish()"
 
         node = hou.node("/out/REMOTE_PUBLISH")
         if not node:
@@ -30,7 +30,7 @@ class ValidateRemotePublishOutNode(pyblish.api.InstancePlugin):
         assert node.type().name() == "shell", "Must be shell ROP node"
         assert node.parm("command").eval() == "", "Must have no command"
         assert not node.parm("shellexec").eval(), "Must not execute in shell"
-        assert node.parm("prerender").eval() == self.cmd, (
+        assert node.parm("prerender").eval() == cmd, (
             "REMOTE_PUBLISH node does not have correct prerender script."
         )
         assert node.parm("lprerender").eval() == "python", (
@@ -38,41 +38,6 @@ class ValidateRemotePublishOutNode(pyblish.api.InstancePlugin):
         )
 
     @classmethod
-    def repair(cls, instance):
+    def repair(cls, context):
         """(Re)create the node if it fails to pass validation"""
-
-        existing = hou.node("/out/REMOTE_PUBLISH")
-        if existing:
-            cls.log.warning("Removing existing '/out/REMOTE_PUBLISH' node..")
-            existing.destroy()
-
-        # Create the shell node
-        out = hou.node("/out")
-        shell = out.createNode("shell", node_name="REMOTE_PUBLISH")
-        shell.moveToGoodPosition()
-
-        # Set the pre-render script
-        shell.setParms({
-            "prerender": cls.cmd,
-            "lprerender": "python"  # command language
-        })
-
-        # Lock the attributes to ensure artists won't easily mess things up.
-        shell.parm("prerender").lock(True)
-        shell.parm("lprerender").lock(True)
-
-        # Lock up the actual shell command
-        command_parm = shell.parm("command")
-        command_parm.set("")
-        command_parm.lock(True)
-        command_parm.hide(True)
-        shellexec_parm = shell.parm("shellexec")
-        shellexec_parm.set(False)
-        shellexec_parm.lock(True)
-        shellexec_parm.hide(True)
-
-        # Tweak the node's template so it's a lot clearer to the artist.
-        # todo: Hide the Shell tab itself (python code below still shows tab)
-        # template = node.parmTemplateGroup()
-        # template.hideFolder("Shell", True)
-        # node.setParmTemplateGroup(template)
+        lib.create_remote_publish_node(force=True)

--- a/colorbleed/scripts/publish_instances.py
+++ b/colorbleed/scripts/publish_instances.py
@@ -12,62 +12,11 @@ log = logging.getLogger("Publish active instances")
 log.setLevel(logging.DEBUG)
 
 
-class CollectInstancesActiveState(pyblish.api.ContextPlugin):
-    """Collect instance active state from PYBLISH_ACTIVE_INSTANCES.
-
-    This will read the PYBLISH_ACTIVE_INSTANCES environment variable and split
-    the string by comma. Only those instances that match by name with the
-    entries in that list will remain active for publishing, the rest will
-    be deactivated.
-
-    """
-    order = pyblish.api.CollectorOrder + 0.499
-
-    def process(self, context):
-
-        active = os.environ.get("PYBLISH_ACTIVE_INSTANCES")
-        if not active:
-            raise RuntimeError("No registered active instances to process"
-                               " in PYBLISH_ACTIVE_INSTANCES.")
-
-        # Make set of valid entries, split by comma
-        active = set(name.strip() for name in active.split(",") if
-                     name.strip())
-
-        found = set()
-        for instance in context:
-
-            # Set the state per instance
-            state = instance.name in active
-            self.log.info("Setting %s publish state to %s" % (instance.name,
-                                                              state))
-            instance.data["active"] = state
-            instance.data["publish"] = state
-
-            if state:
-                found.add(instance.name)
-
-        # Ensure all PYBLISH_ACTIVE_INSTANCES are found so that we can
-        # expect the publish to be consistent with what the user requested
-        missing = active - found
-        if missing:
-            raise RuntimeError("Missing subsets: %s" % list(missing))
-
-
 def publish():
     # Note: This function assumes Avalon has been installed prior to this.
     #       As such it does *not* trigger avalon.api.install().
-
-    # First register the plug-in that ensures only the instances defined in
-    # PYBLISH_ACTIVE_INSTANCES remain enabled directly after collection.
-    pyblish.api.register_plugin(CollectInstancesActiveState)
-
+    print("Starting pyblish.util.pyblish()..")
     context = pyblish.util.publish()
-
-    # Cleanup afterwards, just to be sure. This is not so important if this
-    # runs in a standalone process that dies after publishing anyway.
-    pyblish.api.deregister_plugin(CollectInstancesActiveState)
-
     print("Finished pyblish.util.publish(), checking for errors..")
 
     if not context:


### PR DESCRIPTION
This PR implements Remote Publish from Houdini where the resulting Deadline jobs become a single Job per instance. This extends the functionality of #251.

**Remote Publish separate job per instance** with https://github.com/Colorbleed/colorbleed-config/commit/8b1c353b2b4507d14542b272de7e01c103c5c239

1. Create a Remote Publish node for its settings, _either through the Creator (Avalon > Create..) or through the Remote Publish validator (right-click > Repair..)_
2. Change the *new* setting on the Remote Publish node, enable "Separate Job Per Instance".
3. Perform a remote publish (see #251 for more details on how to currently do that).

---

**Deadline update percentage of completion** with https://github.com/Colorbleed/colorbleed-config/commit/3c12936d3fad61a4c45fdd6216af2a9d785a33cd

Additionally this also enables the Alfred-style reporting of the renders which Deadline should be able to pick up to update the percentage of completion bar during the publish. (Note that when multiple instances are publishing in a single job this will likely go through 0%-100% for *each publish instance*)

---

**Remote Publish node now hides all default "Shell" node settings** with [commit](https://github.com/Colorbleed/colorbleed-config/commit/8b1c353b2b4507d14542b272de7e01c103c5c239#diff-a65e1d7eafe2c75076333a7ee0f067c2R289)

The Remote Publish node has been tweaked to hide all default settings and tabs and *only* show the newly added Submission Settings, which currently only contains the "Separate Job per Instance" attribute.

![remote_publish](https://user-images.githubusercontent.com/2439881/64679217-96592000-d47b-11e9-8d74-e59ac48a190b.jpg)

---

Note: This also [simplifies the remote publish script for Maya](https://github.com/Colorbleed/colorbleed-config/commit/8b1c353b2b4507d14542b272de7e01c103c5c239#diff-27da0332a0faa92392de759f944f012cL15) as the [collection of the active Pyblish instance state that is sent along is now a global `CollectInstancesActiveState` plug-in.](https://github.com/Colorbleed/colorbleed-config/commit/8b1c353b2b4507d14542b272de7e01c103c5c239#diff-c66fc9f7857c5d92afc57d72d83fda09R5)