### PR TITLE
Skip Maya scene save on publish if no modifications prior to Extraction

### DIFF
--- a/colorbleed/plugins/maya/publish/save_scene.py
+++ b/colorbleed/plugins/maya/publish/save_scene.py
@@ -19,7 +19,7 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
         current = cmds.file(query=True, sceneName=True)
         assert context.data['currentFile'] == current
 
-        # If save has no modifications, skip forcing a file save
+        # If file has no modifications, skip forcing a file save
         if not cmds.file(query=True, modified=True):
             self.log.debug("Skipping file save as there "
                            "are no modifications..")

--- a/colorbleed/plugins/maya/publish/save_scene.py
+++ b/colorbleed/plugins/maya/publish/save_scene.py
@@ -2,12 +2,14 @@ import pyblish.api
 
 
 class SaveCurrentScene(pyblish.api.ContextPlugin):
-    """Save current scene
+    """Save current scene before extraction.
+
+    This will skip saving scene if the current file has no modified changes.
 
     """
 
     label = "Save current file"
-    order = pyblish.api.IntegratorOrder - 0.49
+    order = pyblish.api.ExtractorOrder - 0.49
     hosts = ["maya"]
     families = ["colorbleed.renderlayer"]
 
@@ -16,6 +18,12 @@ class SaveCurrentScene(pyblish.api.ContextPlugin):
 
         current = cmds.file(query=True, sceneName=True)
         assert context.data['currentFile'] == current
+
+        # If save has no modifications, skip forcing a file save
+        if not cmds.file(query=True, modified=True):
+            self.log.debug("Skipping file save as there "
+                           "are no modifications..")
+            return
 
         self.log.info("Saving current file..")
         cmds.file(save=True, force=True)


### PR DESCRIPTION
With this change the SaveCurrentScene publish plug-in for Maya will **not** save if the current scene modified state is false. (`not cmds.file(query=True, modified=True)`).

The save scene plug-in has also been moved to just before Extraction as opposed to Integration. This is due to some Extractors have maya think the file needs to be saved even when it doesn't. Plus, in general we actually want to save prior to extracting too to make sure nothing messes up the current file if code fails to be as safe as we assume.