### PR TITLE
Improve Houdini Remote Publish workflow

### DIFF
--- a/colorbleed/houdini/lib.py
+++ b/colorbleed/houdini/lib.py
@@ -265,6 +265,9 @@ def create_remote_publish_node(force=True):
     node = out.createNode("shell", node_name="REMOTE_PUBLISH")
     node.moveToGoodPosition()
 
+    # Set color make it stand out (avalon/pyblish color)
+    node.setColor(hou.Color(0.439, 0.709, 0.933))
+
     # Set the pre-render script
     node.setParms({
         "prerender": cmd,

--- a/colorbleed/plugins/houdini/publish/validate_remote_publish.py
+++ b/colorbleed/plugins/houdini/publish/validate_remote_publish.py
@@ -9,7 +9,7 @@ import hou
 class ValidateRemotePublishOutNode(pyblish.api.ContextPlugin):
     """Validate the remote publish out node exists for Deadline to trigger."""
 
-    order = colorbleed.api.ValidateContentsOrder - 0.4
+    order = pyblish.api.ValidatorOrder - 0.4
     families = ["*"]
     hosts = ['houdini']
     targets = ["deadline"]

--- a/colorbleed/plugins/houdini/publish/validate_remote_publish_enabled.py
+++ b/colorbleed/plugins/houdini/publish/validate_remote_publish_enabled.py
@@ -1,0 +1,35 @@
+import pyblish.api
+import colorbleed.api
+
+import hou
+
+
+class ValidateRemotePublishEnabled(pyblish.api.ContextPlugin):
+    """Validate the remote publish node is *not* bypassed."""
+
+    order = colorbleed.api.ValidateContentsOrder - 0.39
+    families = ["*"]
+    hosts = ['houdini']
+    targets = ["deadline"]
+    label = 'Remote Publish ROP enabled'
+    actions = [colorbleed.api.RepairContextAction]
+
+    def process(self, context):
+
+        node = hou.node("/out/REMOTE_PUBLISH")
+        if not node:
+            raise RuntimeError("Missing REMOTE_PUBLISH node.")
+
+        if node.isBypassed():
+            raise RuntimeError("REMOTE_PUBLISH must not be bypassed.")
+
+    @classmethod
+    def repair(cls, context):
+        """(Re)create the node if it fails to pass validation"""
+
+        node = hou.node("/out/REMOTE_PUBLISH")
+        if not node:
+            raise RuntimeError("Missing REMOTE_PUBLISH node.")
+
+        cls.log.info("Disabling bypass on /out/REMOTE_PUBLISH")
+        node.bypass(False)

--- a/colorbleed/plugins/houdini/publish/validate_remote_publish_enabled.py
+++ b/colorbleed/plugins/houdini/publish/validate_remote_publish_enabled.py
@@ -7,7 +7,7 @@ import hou
 class ValidateRemotePublishEnabled(pyblish.api.ContextPlugin):
     """Validate the remote publish node is *not* bypassed."""
 
-    order = colorbleed.api.ValidateContentsOrder - 0.39
+    order = pyblish.api.ValidatorOrder - 0.39
     families = ["*"]
     hosts = ['houdini']
     targets = ["deadline"]


### PR DESCRIPTION
- Make `REMOTE_PUBLISH` node stand out more by giving it pyblish/avalon icon colors.
- Validate the `REMOTE_PUBLISH` node is **not** set to bypass, otherwise the render job will do nothing.
- Clean-up some code for the ordering of the plug-ins.