### PR TITLE
Add 'renderer' subfamily to target plugins + validate arnold verbosity

### DIFF
--- a/colorbleed/plugins/maya/publish/collect_renderlayers.py
+++ b/colorbleed/plugins/maya/publish/collect_renderlayers.py
@@ -88,6 +88,11 @@ class CollectMayaRenderlayers(pyblish.api.ContextPlugin):
                 "source": filepath
             }
 
+            # Include the renderer in the families so we can direct specific
+            # validators to specific renderers.
+            renderer_family = "colorbleed.renderlayer.%s" % data["renderer"]
+            data["families"].append(renderer_family)
+
             # Apply each user defined attribute as data
             for attr in cmds.listAttr(layer, userDefined=True) or list():
                 try:

--- a/colorbleed/plugins/maya/publish/validate_arnold_layername.py
+++ b/colorbleed/plugins/maya/publish/validate_arnold_layername.py
@@ -11,7 +11,7 @@ class ValidateArnoldLayerName(pyblish.api.InstancePlugin):
     order = colorbleed.api.ValidateContentsOrder
     label = "Arnold Preserve Layer Name"
     hosts = ["maya"]
-    families = ["colorbleed.renderlayer"]
+    families = ["colorbleed.renderlayer.arnold"]
     actions = [colorbleed.api.RepairAction]
 
     def process(self, instance):

--- a/colorbleed/plugins/maya/publish/validate_arnold_log_vebosity.py
+++ b/colorbleed/plugins/maya/publish/validate_arnold_log_vebosity.py
@@ -1,0 +1,51 @@
+import maya.cmds as cmds
+
+import pyblish.api
+import colorbleed.api
+import colorbleed.maya.lib as lib
+
+
+class ValidateArnoldLogVerbosity(pyblish.api.InstancePlugin):
+    """Validate log verbosity is set to higher or equal to Info for Arnold.
+
+    With a lower verbosity than "Info" Arnold will *not* report any progress
+    of the render job. As such Deadline can't show the render percentage nor
+    will the logs show any information about the state of the render.
+
+    Available verbosity levels for Arnold are:
+        - 0: Errors
+        - 1: Warnings
+        - 2: Info
+        - 3: Debug
+
+    """
+
+    order = colorbleed.api.ValidateContentsOrder
+    label = "Arnold Log Verbosity"
+    hosts = ["maya"]
+    families = ["colorbleed.renderlayer.arnold"]
+    actions = [colorbleed.api.RepairAction]
+
+    verbosity_attr = "defaultArnoldRenderOptions.log_verbosity"
+
+    def process(self, instance):
+
+        if instance.data.get("renderer", None) != "arnold":
+            # If not rendering with Arnold, ignore..
+            return
+
+        attr = self.verbosity_attr
+        assert cmds.ls(attr), (
+            "Arnold render options node does not exist, missing %s" % attr
+        )
+
+        verbosity = cmds.getAttr(attr)
+        if verbosity < 2:
+            raise RuntimeError("Arnold log verbosity is lower than 'Info'. "
+                               "Please set the logging to Info or higher so "
+                               "the render job will report its progress.")
+
+    @classmethod
+    def repair(cls, instance):
+        # Set verbosity level: Info
+        cmds.setAttr(cls.verbosity_attr, 2)

--- a/colorbleed/plugins/maya/publish/validate_vray_cache_settings.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_cache_settings.py
@@ -7,35 +7,35 @@ from maya import cmds
 
 class ValidateVRayCacheSettings(pyblish.api.InstancePlugin):
     """Validate V-Ray Plug-in Geometry and Bitmap cache.
-    
-    In some rare scenarios the caching can mess up batch rendering where it 
-    "holds" geometry from a different frame ending up with a render in a new 
+
+    In some rare scenarios the caching can mess up batch rendering where it
+    "holds" geometry from a different frame ending up with a render in a new
     frame that does not have updated geometry (for some meshes). However,
     this happens very rarely and is hard to reproduce.
-    
+
     For sake of clarity, we will raise a warning with this validator however.
-    
+
     These settings are in Render Settings > Overrides > Rendering.
 
     """
 
     order = colorbleed.api.ValidateContentsOrder
     label = "VRay Cache Geometry/Bitmaps"
-    families = ["colorbleed.renderlayer"]
+    families = ["colorbleed.renderlayer.vray"]
 
     def process(self, instance):
 
-        if instance.data.get("renderer") != "vray":
-            # If not V-Ray ignore..
-            return
-
         vray_settings = cmds.ls("vraySettings", type="VRaySettingsNode")
         assert vray_settings, "Please ensure a VRay Settings Node is present"
-        
+
+        node = vray_settings[0]
+
         # Cache geometry plug-ins between renders
-        if cmds.getAttr("{0}.globopt_cache_geom_plugins".format(vray_settings[0])):
-            self.log.warning("V-Ray Overrides: Cache Geometry Plug-ins is currently enabled..")
-            
+        if cmds.getAttr("{0}.globopt_cache_geom_plugins".format(node)):
+            self.log.warning("V-Ray Overrides: Cache Geometry Plug-ins "
+                             "is currently enabled..")
+
         # Cache bitmaps between renders
-        if cmds.getAttr("{0}.globopt_cache_bitmaps".format(vray_settings[0])):
-            self.log.warning("V-Ray Overrides: Cache Bitmaps is currently enabled..")
+        if cmds.getAttr("{0}.globopt_cache_bitmaps".format(node)):
+            self.log.warning("V-Ray Overrides: Cache Bitmaps "
+                             "is currently enabled..")

--- a/colorbleed/plugins/maya/publish/validate_vray_distributed_rendering.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_distributed_rendering.py
@@ -17,7 +17,7 @@ class ValidateVRayDistributedRendering(pyblish.api.InstancePlugin):
 
     order = colorbleed.api.ValidateContentsOrder
     label = "VRay Distributed Rendering"
-    families = ["colorbleed.renderlayer"]
+    families = ["colorbleed.renderlayer.vray"]
     actions = [colorbleed.api.RepairAction]
 
     # V-Ray attribute names

--- a/colorbleed/plugins/maya/publish/validate_vray_distributed_rendering.py
+++ b/colorbleed/plugins/maya/publish/validate_vray_distributed_rendering.py
@@ -26,10 +26,6 @@ class ValidateVRayDistributedRendering(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        if instance.data.get("renderer") != "vray":
-            # If not V-Ray ignore..
-            return
-
         vray_settings = cmds.ls("vraySettings", type="VRaySettingsNode")
         assert vray_settings, "Please ensure a VRay Settings Node is present"
 


### PR DESCRIPTION
- Append a `colorbleed.renderlayer.{renderer}` subfamily to renderlayer instances so we can target specific validators to only specific renderers.
- Add a validator that checks whether Arnold's logging verbosity is set to at least "Info" or higher. Without it the render job would not report any progress nor is Deadline able to pick up a render completion percentage.