### PR TITLE
Minor fixes, add Inherit Transforms validator, plus add repair to look default shader connections validator

### DIFF
--- a/colorbleed/plugins/maya/create/colorbleed_fbx.py
+++ b/colorbleed/plugins/maya/create/colorbleed_fbx.py
@@ -26,3 +26,6 @@ class CreateFBX(avalon.maya.Creator):
         # FBX extraction so the FBX exporter picks up these custom animation
         # layers. This will currently *only* bake joints.
         self.data["bakeAnimLayers"] = ""
+
+        # Whether to preserve instances in the export
+        self.data["instances"] = False

--- a/colorbleed/plugins/maya/publish/extract_animation.py
+++ b/colorbleed/plugins/maya/publish/extract_animation.py
@@ -65,6 +65,7 @@ class ExtractColorbleedAnimation(colorbleed.api.Extractor):
             "selection": True,
             "worldSpace": instance.data.get("worldSpace", True),
             "eulerFilter": instance.data.get("eulerFilter", True),
+            "writeColorSets": instance.data.get("writeColorSets", False)
         }
 
         if not instance.data.get("includeParentHierarchy", True):

--- a/colorbleed/plugins/maya/publish/extract_pointcache.py
+++ b/colorbleed/plugins/maya/publish/extract_pointcache.py
@@ -75,9 +75,6 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
         attr_prefixes = [value for value in attr_prefixes if value.strip()]
         attr_prefixes.append("cb_")
 
-        # Get extra export arguments
-        writeColorSets = instance.data.get("writeColorSets", False)
-
         self.log.info("Extracting pointcache..")
         dirname = self.staging_dir(instance)
 
@@ -91,7 +88,7 @@ class ExtractColorbleedAlembic(colorbleed.api.Extractor):
             "attrPrefix": attr_prefixes,
             "writeVisibility": True,
             "writeCreases": True,
-            "writeColorSets": writeColorSets,
+            "writeColorSets": instance.data.get("writeColorSets", False),
             "uvWrite": True,
             "selection": True,
             "worldSpace": instance.data.get("worldSpace", True)

--- a/colorbleed/plugins/maya/publish/validate_inherit_transforms.py
+++ b/colorbleed/plugins/maya/publish/validate_inherit_transforms.py
@@ -1,0 +1,62 @@
+from maya import cmds
+
+import pyblish.api
+import colorbleed.api
+import colorbleed.action
+import colorbleed.maya.action
+
+
+class RepairAction(colorbleed.action.RepairAction):
+    # todo: allow this to only show on warning when pyblish allows it
+    on = "processed"
+
+
+class SelectAction(colorbleed.maya.action.SelectInvalidAction):
+    # todo: allow this to only show on warning when pyblish allows it
+    label = "Select"
+    on = "processed"
+
+
+class ValidateInheritsTransform(pyblish.api.InstancePlugin):
+    """Validates whether transforms have 'inherit transforms' enabled.
+
+    It is technically allowed to disable "Inherit Transforms" however in most
+    scenarios it's unwanted. As such we will show a warning whenever transform
+    nodes have it disabled.
+
+    """
+
+    order = colorbleed.api.ValidateContentsOrder
+    families = ["colorbleed.model",
+                "colorbleed.pointcache"]
+    hosts = ["maya"]
+    label = "Inherits Transforms"
+    actions = [SelectAction, RepairAction]
+
+    @classmethod
+    def get_invalid(cls, instance):
+
+        invalid = []
+        transforms = cmds.ls(instance[:], type="transform", long=True)
+        for transform in transforms:
+            inherit_transform = cmds.getAttr(transform + ".inheritsTransform")
+            if not inherit_transform:
+                invalid.append(transform)
+
+        return invalid
+
+    def process(self, instance):
+        """Process all the nodes in the instance"""
+
+        invalid = self.get_invalid(instance)
+        if invalid:
+            self.log.warning("Transforms found with inherit "
+                             "transform disabled: {0}".format(invalid))
+
+    @classmethod
+    def repair(cls, instance):
+
+        for transform in cls.get_invalid(instance):
+            cls.log.info("Enabling inherits transform on: "
+                         "{0}".format(transform))
+            cmds.setAttr(transform + ".inheritsTransform", True)


### PR DESCRIPTION
This implements some minor fixes and cleanup:

- Extract animation now actually uses the `writeColorSets` attribute so it can include color sets if it needs to.
- Added a new validator for `colorbleed.model` and `colorbleed.pointcache` family that **warns** the user whenever a transform node has **Inherits Transform** disabled. This also includes two actions to select the invalid nodes and repair them automatically (enabling the attribute) if the user wants to debug. Note: It being a warning means the user is **not** required to fix it. Publishing is allowed with Inherits Transform disabled if needed for production.
- Added repair function to `ValidateLookDefaultShadersConnections`. It's a relatively obscure thing that happens only very occasionally and seemingly randomly. This repair at least allows users to quickly patch things back up to what they originally should be.
- Patched up the model and pointcache Alembic Extractor so that whenever both parent and children nodes are inside the publish instance the "children" are ignored and will not be passed to the Alembic extraction job as 'root' nodes as that would previously allow the Extractor to fail. Only the *highest nodes in the hierarchies* in the input set are considered to be root nodes.
- Add option to `colorbleed.fbx` family to enable the **Preserve Instances** feature of the Maya FBX Exporter.