### PR TITLE
Update vendorized `speedcopy` to v2.0

### DIFF
--- a/colorbleed/vendor/speedcopy/__init__.py
+++ b/colorbleed/vendor/speedcopy/__init__.py
@@ -2,24 +2,88 @@
 Speed up shutil.copyfile by using sendfile system call and robocopy for
 windows. Based on `pyfastcopy`, extending it to windows.
 """
-
-__version__ = "1.0.0"
-__author__ = "annatar"
-__license__ = "MIT"
-
 import errno
 import os
 import shutil
 import stat
 import sys
+import ctypes
+
+SPEEDCOPY_DEBUG = False
+
+
+def debug(msg):
+    if SPEEDCOPY_DEBUG:
+        print(msg)
 
 
 if not sys.platform.startswith("win32"):
     try:
         _sendfile = os.sendfile
     except AttributeError:
-        import sendfile
-        _sendfile = sendfile.sendfile
+        try:
+            import sendfile
+        except ImportError:
+            _sendfile = None
+        else:
+            _sendfile = sendfile.sendfile
+    from fcntl import ioctl
+    import ctypes.util
+    from ctypes import c_int
+    from .fstatfs import FilesystemInfo
+
+    CIFS_MAGIC_NUMBER = 0xFF534D42
+    SMB2_MAGIC_NUMBER = 0xFE534D42
+
+    _IOC_NRBITS = 8
+    _IOC_TYPEBITS = 8
+    _IOC_SIZEBITS = 14
+    _IOC_DIRBITS = 2
+
+    _IOC_NRMASK = (1 << _IOC_NRBITS) - 1
+    _IOC_TYPEMASK = (1 << _IOC_TYPEBITS) - 1
+    _IOC_SIZEMASK = (1 << _IOC_SIZEBITS) - 1
+    _IOC_DIRMASK = (1 << _IOC_DIRBITS) - 1
+
+    _IOC_NRSHIFT = 0
+    _IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS
+    _IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS
+    _IOC_DIRSHIFT = _IOC_SIZESHIFT + _IOC_SIZEBITS
+
+    IOC_NONE = 0
+    IOC_WRITE = 1
+    IOC_READ = 2
+
+    def IOC_TYPECHECK(t):
+        """
+        Returns the size of given type, and check its suitability for use in an
+        ioctl command number.
+        """
+        result = ctypes.sizeof(t)
+        assert result <= _IOC_SIZEMASK, result
+        return result
+
+    def IOC(dir, type, nr, size):
+        """
+        dir
+            One of IOC_NONE, IOC_WRITE, IOC_READ, or IOC_READ|IOC_WRITE.
+            Direction is from the application's point of view, not kernel's.
+        size (14-bits unsigned integer)
+            Size of the buffer passed to ioctl's "arg" argument.
+        """
+        assert dir <= _IOC_DIRMASK, dir
+        assert type <= _IOC_TYPEMASK, type
+        assert nr <= _IOC_NRMASK, nr
+        assert size <= _IOC_SIZEMASK, size
+        return (dir << _IOC_DIRSHIFT) | (type << _IOC_TYPESHIFT) | (nr << _IOC_NRSHIFT) | (size << _IOC_SIZESHIFT)  # noqa: E501
+
+    def IOW(type, nr, size):
+        """
+        An ioctl with write parameters.
+        size (ctype type or instance)
+            Type/structure of the argument passed to ioctl's "arg" argument.
+        """
+        return IOC(IOC_WRITE, type, nr, IOC_TYPECHECK(size))
 
     # errnos sendfile can set if not supported on the system
     _sendfile_err_codes = {code for code, name in errno.errorcode.items()
@@ -30,6 +94,8 @@ if not sys.platform.startswith("win32"):
         """
         Copy data from fsrc to fdst using sendfile, return True if success.
         """
+        if not _sendfile:
+            return False
         status = False
         max_bcount = 2 ** 31 - 1
         bcount = max_bcount
@@ -46,8 +112,10 @@ if not sys.platform.startswith("win32"):
             if e.errno in _sendfile_err_codes:
                 # sendfile is not supported or does not support classic
                 # files (only sockets)
+                debug("!!! sendfile not supported: {}".format(e.errno))
                 pass
             else:
+                debug("!!! sendfile other error {}".format(e))
                 raise
         return status
 
@@ -63,45 +131,65 @@ if not sys.platform.startswith("win32"):
         for fn in [src, dst]:
             try:
                 st = os.stat(fn)
-            except OSError:
+            except OSError as e:
                 # File most likely does not exist
-                pass
+                debug(">>> {} doesn't exists [ {} ]".format(fn, e))
             else:
                 # XXX What about other special files? (sockets, devices...)
                 if stat.S_ISFIFO(st.st_mode):
                     raise shutil.SpecialFileError("`%s` is a named pipe" % fn)
 
         if not follow_symlinks and os.path.islink(src):
+            debug(">>> creating symlink ...")
             os.symlink(os.readlink(src), dst)
         else:
-            with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
-                # Try to use sendfile if available for performance
-                if not _copyfile_sendfile(fsrc, fdst):
-                    # sendfile is not available or failed, fallback
-                    # to copyfileobj
-                    shutil.copyfileobj(fsrc, fdst)
+            fs_src_type = FilesystemInfo().filesystem(src.encode('utf-8'))
+            fs_dst_type = FilesystemInfo().filesystem(
+                os.path.dirname(dst.encode('utf-8')))
+            supported_fs = ['CIFS', 'SMB2']
+            debug(">>> Source FS: {}".format(fs_src_type))
+            debug(">>> Destination FS: {}".format(fs_dst_type))
+            if fs_src_type in supported_fs and fs_dst_type in supported_fs:
+                fsrc = os.open(src, os.O_RDONLY)
+                fdst = os.open(dst, os.O_WRONLY | os.O_CREAT)
+
+                CIFS_IOCTL_MAGIC = 0xCF
+                CIFS_IOC_COPYCHUNK_FILE = IOW(CIFS_IOCTL_MAGIC, 3, c_int)
+
+                # try copy file with COW support on Linux. If fail, fallback
+                # to sendfile and if this is not available too, fallback
+                # copyfileobj.
+                ret = ioctl(fdst, CIFS_IOC_COPYCHUNK_FILE, fsrc)
+                os.close(fsrc)
+                os.close(fdst)
+                if ret != 0:
+                    debug("!!! failed {}".format(ret))
+                    os.close(fsrc)
+                    os.close(fdst)
+                    # Try to use sendfile if available for performance
+                    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
+                        if not _copyfile_sendfile(fsrc, fdst):
+                            debug("!!! failed sendfile")
+                            # sendfile is not available or failed, fallback
+                            # to copyfileobj
+                            shutil.copyfileobj(fsrc, fdst)
+            else:
+                with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
+                    if not _copyfile_sendfile(fsrc, fdst):
+                        # sendfile is not available or failed, fallback
+                        # to copyfileobj
+                        shutil.copyfileobj(src, dst)
+
         return dst
 
 else:
     def copyfile(src, dst, follow_symlinks=True):
         """Copy data from src to dst.
-        It uses windows `xcopy` method to do so, making advantage of
-        server-side copy where available. Different other methods can be used
-        as robocopy is probably faster, but robocopy doesn't support renaming
-        destination file when copying just one file :( Shame on you Microsoft.
+        It uses windows native CopyFileW method to do so, making advantage of
+        server-side copy where available.
         """
-        from subprocess import call
-        
-        try:
-            # Python 3.3+
-            from subprocess import DEVNULL
-        except ImportError:
-            # Backwards compatibility
-            DEVNULL = open(os.devnull, 'w')
-        
-        # from pathlib import Path, PureWindowsPath
+
         if shutil._samefile(src, dst):
-        
             # Get shutil.SameFileError if available (Python 3.4+)
             # else fall back to original behavior using shutil.Error
             SameFileError = getattr(shutil, "SameFileError", shutil.Error)
@@ -122,23 +210,35 @@ else:
         if not follow_symlinks and os.path.islink(src):
             os.symlink(os.readlink(src), dst)
         else:
-            # call(["xcopy", src, dst], stdin=DEVNULL, stdout=DEVNULL)
+            kernel32 = ctypes.WinDLL('kernel32',
+                                     use_last_error=True, use_errno=True)
+            copyfile = kernel32.CopyFile2
+            copyfile.argtypes = (ctypes.c_wchar_p,
+                                 ctypes.c_wchar_p,
+                                 ctypes.c_void_p)
+            copyfile.restype = ctypes.HRESULT
 
-            cmd = ["echo", "f", "|", "xcopy", "/y", "/h", "/r",
-                   src.replace('/', '\\'), dst.replace('/', '\\')]
-            # cmd = ["copy", "/B", "/Y",
-            #        src.replace('/', '\\'), dst.replace('/', '\\')]
-            call(cmd, stdin=DEVNULL, stdout=DEVNULL, shell=True)
+            source_file = os.path.normpath(src)
+            dest_file = os.path.normpath(dst)
+            if source_file.startswith('\\\\'):
+                source_file = 'UNC\\' + source_file[2:]
+            if dest_file.startswith('\\\\'):
+                dest_file = 'UNC\\' + dest_file[2:]
 
-            # call(["robocopy",
-            #       os.path.dirname(src),
-            #       os.path.dirname(dst),
-            #       os.path.basename(src),
-            #       "/njh", "/njs", "/ndl", "/nc", "/ns", "/nfl"])
-            # os.rename(os.path.join(
-            #     os.path.dirname(dst), os.path.basename(src)),
-            #     dst)
-            # call(["copy", src, dst, "/B", "/Y"])
+            ret = copyfile('\\\\?\\' + source_file,
+                           '\\\\?\\' + dest_file, None)
+
+            if ret != 0:
+                error = ctypes.get_last_error()
+                if error == 0:
+                    return dst
+                # 997 is ERROR_IO_PENDING. Why it is poping here with
+                # CopyFileW is beyond me, but  assume we can easily
+                # ignore it as it is copying nevertheless
+                if error == 997:
+                    return dst
+                raise IOError(
+                    "File {!r} copy failed, error: {}".format(src, error))
         return dst
 
 

--- a/colorbleed/vendor/speedcopy/fstatfs.py
+++ b/colorbleed/vendor/speedcopy/fstatfs.py
@@ -1,0 +1,165 @@
+"""
+python fstatfs implementation taken from:
+https://github.com/mithro/rcfiles
+"""
+import os
+import ctypes
+import ctypes.util
+
+
+libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+
+class Fs_types:
+    # Constants for filesystem magic
+    # https://www.gnu.org/software/coreutils/filesystems.html
+    filesystems = {
+        "ADFS_SUPER_MAGIC": 0xadf5,
+        "AFFS_SUPER_MAGIC": 0xADFF,
+        "BEFS_SUPER_MAGIC": 0x42465331,
+        "BFS_MAGIC": 0x1BADFACE,
+        "CIFS_MAGIC_NUMBER": 0xFF534D42,
+        "CODA_SUPER_MAGIC": 0x73757245,
+        "COH_SUPER_MAGIC": 0x012FF7B7,
+        "CRAMFS_MAGIC": 0x28cd3d45,
+        "DEVFS_SUPER_MAGIC": 0x1373,
+        "EFS_SUPER_MAGIC": 0x00414A53,
+        "EXT_SUPER_MAGIC": 0x137D,
+        "EXT2_OLD_SUPER_MAGIC": 0xEF51,
+        "EXT2_SUPER_MAGIC": 0xEF53,
+        "EXT3_SUPER_MAGIC": 0xEF53,
+        "HFS_SUPER_MAGIC": 0x4244,
+        "HPFS_SUPER_MAGIC": 0xF995E849,
+        "HUGETLBFS_MAGIC": 0x958458f6,
+        "ISOFS_SUPER_MAGIC": 0x9660,
+        "JFFS2_SUPER_MAGIC": 0x72b6,
+        "JFS_SUPER_MAGIC": 0x3153464a,
+        "MINIX_SUPER_MAGIC": 0x137F,  # orig. minix
+        "MINIX_SUPER_MAGIC2": 0x138F,  # 30 char minix
+        "MINIX2_SUPER_MAGIC": 0x2468,  # minix V2
+        "MINIX2_SUPER_MAGIC2": 0x2478,  # minix V2, 30 char names
+        "MSDOS_SUPER_MAGIC": 0x4d44,
+        "NCP_SUPER_MAGIC": 0x564c,
+        "NFS_SUPER_MAGIC": 0x6969,
+        "NTFS_SB_MAGIC": 0x5346544e,
+        "OPENPROM_SUPER_MAGIC": 0x9fa1,
+        "PROC_SUPER_MAGIC": 0x9fa0,
+        "QNX4_SUPER_MAGIC": 0x002f,
+        "REISERFS_SUPER_MAGIC": 0x52654973,
+        "ROMFS_MAGIC": 0x7275,
+        "SMB_SUPER_MAGIC": 0x517B,
+        "SMB2_SUPER_MAGIC": 0xfe534d42,
+        "SYSV2_SUPER_MAGIC": 0x012FF7B6,
+        "SYSV4_SUPER_MAGIC": 0x012FF7B5,
+        "TMPFS_MAGIC": 0x01021994,
+        "UDF_SUPER_MAGIC": 0x15013346,
+        "UFS_MAGIC": 0x00011954,
+        "USBDEVICE_SUPER_MAGIC": 0x9fa2,
+        "VXFS_SUPER_MAGIC": 0xa501FCF5,
+        "XENIX_SUPER_MAGIC": 0x012FF7B4,
+        "XFS_SUPER_MAGIC": 0x58465342,
+        "_XIAFS_SUPER_MAGIC": 0x012FD16D
+    }
+
+    types = {}
+
+    def __init__(self):
+        for name, value in self.filesystems.items():
+            if name.endswith('MAGIC'):
+                hname = name[:-6]
+                hname = hname.replace('_SUPER', '')
+                self.types[value] = hname
+
+
+class statfs_t(ctypes.Structure):
+    """
+    Describes the details about a filesystem.
+
+    f_type:    type of file system (see below)
+    f_bsize:   optimal transfer block size
+    f_blocks:  total data blocks in file system
+    f_bfree:   free blocks in fs
+    f_bavail:  free blocks avail to non-superuser
+    f_files:   total file nodes in file system
+    f_ffree:   free file nodes in fs
+    f_fsid:    file system id
+    f_namelen: maximum length of filenames
+    """
+    _fields_ = [
+        ("f_type",    ctypes.c_long),   # type of file system (see below)
+        ("f_bsize",   ctypes.c_long),   # optimal transfer block size
+        ("f_blocks",  ctypes.c_long),   # total data blocks in file system
+        ("f_bfree",   ctypes.c_long),   # free blocks in fs
+        ("f_bavail",  ctypes.c_long),   # free blocks avail to non-superuser
+        ("f_files",   ctypes.c_long),   # total file nodes in file system
+        ("f_ffree",   ctypes.c_long),   # free file nodes in fs
+        ("f_fsid",    ctypes.c_int*2),  # file system id
+        ("f_namelen", ctypes.c_long),   # maximum length of filenames
+        # statfs_t has a bunch of extra padding,
+        # we hopefully guess large enough.
+        ("padding",   ctypes.c_char*1024),
+    ]
+
+
+class FilesystemInfo():
+
+    def __init__(self):
+        self._statfs = libc.statfs
+        self._statfs.argtypes = [ctypes.c_char_p, ctypes.POINTER(statfs_t)]
+        self._statfs.rettype = ctypes.c_int
+
+        self._fstatfs = libc.fstatfs
+        self._fstatfs.argtypes = [ctypes.c_int, ctypes.POINTER(statfs_t)]
+        self._fstatfs.rettype = ctypes.c_int
+
+    def statfs(self, path):
+        """
+        The function statfs() returns information about a mounted file system.
+        Args:
+            path: is the pathname of any file within the mounted file system.
+        Returns:
+            Returns a statfs_t object.
+        """
+        buf = statfs_t()
+        err = self._statfs(path, ctypes.byref(buf))
+        if err == -1:
+            errno = ctypes.get_errno()
+            raise OSError(errno, '%s path: %r' % (os.strerror(errno), path))
+        return buf
+
+    def fstatfs(self, fd):
+        """
+        The fuction fstatfs() returns information about a mounted file ssytem.
+        Args:
+            fd: A file descriptor.
+        Returns:
+            Returns a statfs_t object.
+        """
+        buf = statfs_t()
+        fileno = fd.fileno()
+        assert fileno
+        err = self._fstatfs(fileno, ctypes.byref(buf))
+        if err == -1:
+            errno = ctypes.get_errno()
+            raise OSError(errno, os.strerror(errno))
+        return buf
+
+    def filesystem(self, path_or_fd):
+        """
+        Get the filesystem type a file/path is on.
+        Args:
+            path_or_fd: A string path or an object which has a fileno function.
+        Returns:
+            A string name of the file system.
+        """
+        if hasattr(path_or_fd, 'fileno'):
+            buf = self.fstatfs(path_or_fd)
+        else:
+            buf = self.statfs(path_or_fd)
+
+        assert buf
+        f_types = Fs_types().types
+        try:
+            return f_types[buf.f_type]
+        except KeyError:
+            return "UNKNOWN"

--- a/colorbleed/vendor/speedcopy/version.py
+++ b/colorbleed/vendor/speedcopy/version.py
@@ -1,0 +1,9 @@
+VERSION_MAJOR = 2
+VERSION_MINOR = 0
+VERSION_PATCH = 0
+
+version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
+version = '%i.%i.%i' % version_info
+__version__ = version
+
+__all__ = ['version', 'version_info', '__version__']


### PR DESCRIPTION
New version of speedcopy should be much faster, especially with many smaller files due to not requiring a subprocess with `xcopy`.